### PR TITLE
Clamp minimap hover preview to viewport and respect scrollbar.

### DIFF
--- a/app/modules/MinimapHover.module.scss
+++ b/app/modules/MinimapHover.module.scss
@@ -7,4 +7,6 @@
   pointer-events: none;
   box-sizing: content-box;
   border-color: $menu-red;
+  width: max-content;
+  height: max-content;
 }

--- a/app/modules/MinimapHover.tsx
+++ b/app/modules/MinimapHover.tsx
@@ -7,6 +7,7 @@ import style from "./MinimapHover.module.scss";
 export default function (props: any) {
   const [isMouseHovering, setIsMouseHovering] = createSignal(false);
   const [mouseCoords, setMouseCoords] = createSignal([0, 0]);
+  let hoverEl: HTMLDivElement | undefined;
 
   const isTouchDevice = () => {
     return "ontouchstart" in window || window.navigator.maxTouchPoints > 0;
@@ -25,9 +26,28 @@ export default function (props: any) {
             <div
               class={style.hover}
               style={{
-                left: `${mouseCoords()[0]}px`,
-                top: `${mouseCoords()[1]}px`,
+                left: `${Math.max(
+                  8,
+                  Math.min(
+                    mouseCoords()[0] + 8,
+                    (typeof window !== "undefined"
+                      ? document.documentElement.clientWidth
+                      : 0) -
+                      (hoverEl?.offsetWidth ?? 256) -
+                      8
+                  )
+                )}px`,
+                top: `${Math.max(
+                  8,
+                  Math.min(
+                    mouseCoords()[1] + 8,
+                    (typeof window !== "undefined" ? window.innerHeight : 0) -
+                      (hoverEl?.offsetHeight ?? 256) -
+                      8
+                  )
+                )}px`,
               }}
+              ref={hoverEl}
             >
               <MinimapImg
                 mapId={props.mapId}

--- a/app/modules/MinimapImg.module.scss
+++ b/app/modules/MinimapImg.module.scss
@@ -4,4 +4,6 @@
   image-rendering: pixelated;
   display: block;
   height: auto;
+  // Prevent global reset from shrinking the preview near viewport edges
+  max-width: none;
 }


### PR DESCRIPTION
Prevents off-screen overflow by clamping with element size, stops shrink on right edge, and uses clientWidth to avoid overlapping the vertical scrollbar.

fixes #70 