### PR TITLE
Fall back to Backblaze B2 when GSFS download fails in bwrender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,9 +668,11 @@ name = "bwrender"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "backblaze",
  "bb8-postgres",
  "chkdraft-bindings",
  "common",
+ "futures-util",
  "log",
  "reqwest",
  "tokio",

--- a/crates/bwrender/Cargo.toml
+++ b/crates/bwrender/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 # Local crates
 chkdraft-bindings = { path = "../chkdraft-bindings" }
 common = { path = "../common" }
+backblaze = { path = "../backblaze" }
 
 # Async runtime
 tokio = { version = "*", features = ["rt-multi-thread", "full"] }
@@ -32,3 +33,4 @@ log = "*"
 
 # Utilities
 uuid = { version = "*", features = ["v4"] }
+futures-util = "*"

--- a/crates/bwrender/src/config.rs
+++ b/crates/bwrender/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
     // GSFS
     pub gsfsfe_endpoint: String,
 
+    // Backblaze B2 (fallback)
+    pub backblaze_key_id: String,
+    pub backblaze_application_key: String,
+
     // Rendering
     pub sc_data_path: String,
     pub render_skin: RenderSkin,
@@ -46,6 +50,10 @@ impl Config {
                 .context("DB_CONNECTIONS must be a number")?,
 
             gsfsfe_endpoint: env::var("GSFSFE_ENDPOINT").context("GSFSFE_ENDPOINT not set")?,
+
+            backblaze_key_id: env::var("BACKBLAZE_KEY_ID").context("BACKBLAZE_KEY_ID not set")?,
+            backblaze_application_key: env::var("BACKBLAZE_APPLICATION_KEY")
+                .context("BACKBLAZE_APPLICATION_KEY not set")?,
 
             sc_data_path: env::var("SC_DATA_PATH").context("SC_DATA_PATH not set")?,
             render_skin: parse_render_skin(

--- a/crates/bwrender/src/main.rs
+++ b/crates/bwrender/src/main.rs
@@ -3,6 +3,9 @@ mod db;
 mod render;
 
 use anyhow::Result;
+use backblaze::api::{b2_authorize_account, b2_download_file_by_name, B2AuthorizeAccount, B2Error};
+use futures_util::StreamExt;
+use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 use tracing_log::LogTracer;
 use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter, Layer};
@@ -10,6 +13,20 @@ use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter, 
 use crate::config::Config;
 use crate::db::{DbPool, UnrenderedMap};
 use crate::render::RenderContext;
+
+struct B2Auth {
+    auth: Option<B2AuthorizeAccount>,
+}
+
+impl B2Auth {
+    fn new() -> Self {
+        Self { auth: None }
+    }
+
+    fn invalidate(&mut self) {
+        self.auth = None;
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -54,6 +71,9 @@ async fn main() -> Result<()> {
     // Setup HTTP client for GSFS
     let http_client = reqwest::Client::new();
 
+    // Cached Backblaze B2 auth (fallback for GSFS failures)
+    let b2_auth = Mutex::new(B2Auth::new());
+
     // Initialize rendering context (loads StarCraft data)
     info!(sc_data_path = %config.sc_data_path, "Loading StarCraft data...");
     let render_ctx = RenderContext::new(&config.sc_data_path, config.render_skin)?;
@@ -66,7 +86,7 @@ async fn main() -> Result<()> {
     // Main loop
     info!("Starting main render loop");
     loop {
-        match process_batch(&config, &pool, &http_client, &render_ctx).await {
+        match process_batch(&config, &pool, &http_client, &render_ctx, &b2_auth).await {
             Ok(processed) => {
                 if processed == 0 {
                     info!(
@@ -94,6 +114,7 @@ async fn process_batch(
     pool: &DbPool,
     client: &reqwest::Client,
     render_ctx: &RenderContext,
+    b2_auth: &Mutex<B2Auth>,
 ) -> Result<usize> {
     let maps = db::get_unrendered_maps(pool, config.render_batch_size).await?;
 
@@ -106,7 +127,7 @@ async fn process_batch(
     let mut processed = 0;
 
     for map in maps {
-        match process_single_map(config, pool, client, render_ctx, &map).await {
+        match process_single_map(config, pool, client, render_ctx, b2_auth, &map).await {
             Ok(()) => {
                 processed += 1;
                 info!(chkblob_hash = %map.chkblob_hash, "Successfully rendered map");
@@ -125,16 +146,102 @@ async fn process_batch(
     Ok(processed)
 }
 
+const MAPBLOB_BUCKET_NAME: &str = "seventyseven-mapblob";
+
+async fn get_or_refresh_b2_auth(
+    config: &Config,
+    client: &reqwest::Client,
+    b2_auth: &Mutex<B2Auth>,
+) -> Result<B2AuthorizeAccount> {
+    let mut lock = b2_auth.lock().await;
+    if let Some(ref auth) = lock.auth {
+        return Ok(auth.clone());
+    }
+    info!("Authenticating with Backblaze B2");
+    let auth = b2_authorize_account(
+        client,
+        &config.backblaze_key_id,
+        &config.backblaze_application_key,
+    )
+    .await?;
+    lock.auth = Some(auth.clone());
+    Ok(auth)
+}
+
+async fn download_from_b2_and_upload_to_gsfs(
+    config: &Config,
+    client: &reqwest::Client,
+    b2_auth: &Mutex<B2Auth>,
+    map: &UnrenderedMap,
+    dest_path: &str,
+) -> Result<()> {
+    let api_info = get_or_refresh_b2_auth(config, client, b2_auth).await?;
+
+    let download_result =
+        b2_download_file_by_name(client, &api_info, MAPBLOB_BUCKET_NAME, &map.mapblob_hash).await;
+
+    let mut stream = match download_result {
+        Ok(stream) => stream,
+        Err(B2Error::BadAuthToken(_) | B2Error::ExpiredAuthToken(_)) => {
+            warn!("B2 auth token expired, re-authenticating");
+            b2_auth.lock().await.invalidate();
+            let api_info = get_or_refresh_b2_auth(config, client, b2_auth).await?;
+            b2_download_file_by_name(client, &api_info, MAPBLOB_BUCKET_NAME, &map.mapblob_hash)
+                .await?
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    // Download to temp file
+    let mut file = tokio::fs::File::create(dest_path).await?;
+    let mut all_bytes = Vec::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        all_bytes.extend_from_slice(&chunk);
+        tokio::io::AsyncWriteExt::write_all(&mut file, &chunk).await?;
+    }
+
+    tokio::io::AsyncWriteExt::flush(&mut file).await?;
+    drop(file);
+
+    info!(
+        chkblob_hash = %map.chkblob_hash,
+        mapblob_hash = %map.mapblob_hash,
+        size = all_bytes.len(),
+        "Downloaded from B2, uploading to GSFS"
+    );
+
+    // Upload to GSFS so future fetches don't need B2
+    if let Err(e) = common::gsfs::gsfs_put_bytes(
+        client,
+        &config.gsfsfe_endpoint,
+        &format!("/mapblob/{}", &map.mapblob_hash),
+        all_bytes,
+    )
+    .await
+    {
+        warn!(
+            mapblob_hash = %map.mapblob_hash,
+            error = %e,
+            "Failed to upload to GSFS after B2 download, continuing with render"
+        );
+    }
+
+    Ok(())
+}
+
 async fn process_single_map(
     config: &Config,
     pool: &DbPool,
     client: &reqwest::Client,
     render_ctx: &RenderContext,
+    b2_auth: &Mutex<B2Auth>,
     map: &UnrenderedMap,
 ) -> Result<()> {
     let start = std::time::Instant::now();
 
-    // 1. Download map file from GSFS to temp file
+    // 1. Download map file from GSFS to temp file, falling back to Backblaze B2
     let temp_path = format!(
         "{}/{}.scx",
         config.temp_dir,
@@ -147,13 +254,24 @@ async fn process_single_map(
         "Downloading map from GSFS"
     );
 
-    common::gsfs::gsfs_download_to_file(
+    let gsfs_result = common::gsfs::gsfs_download_to_file(
         client,
         &config.gsfsfe_endpoint,
         &format!("/mapblob/{}", &map.mapblob_hash),
         &temp_path,
     )
-    .await?;
+    .await;
+
+    if let Err(e) = gsfs_result {
+        warn!(
+            chkblob_hash = %map.chkblob_hash,
+            mapblob_hash = %map.mapblob_hash,
+            error = %e,
+            "GSFS download failed, falling back to Backblaze B2"
+        );
+
+        download_from_b2_and_upload_to_gsfs(config, client, b2_auth, map, &temp_path).await?;
+    }
 
     // 2. Render map to WebP
     info!(chkblob_hash = %map.chkblob_hash, "Rendering map");


### PR DESCRIPTION
When GSFS returns an error for a mapblob download, the renderer now fetches the map directly from Backblaze B2, uploads it to GSFS for future use, then proceeds with rendering. B2 auth is cached and only refreshed when missing or expired.