### PR TITLE
Add workspace clippy lints and pin all dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,27 +524,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
-dependencies = [
- "bitflags 2.9.3",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.106",
 ]
@@ -797,7 +777,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 name = "chkdraft-bindings"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "cc",
 ]
 
@@ -836,7 +816,7 @@ dependencies = [
 name = "compact_enc_det-bindings"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
 ]
 
 [[package]]
@@ -2526,12 +2506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,7 +2836,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "stormlib-bindings"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
 ]
 
 [[package]]
@@ -3219,7 +3193,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 name = "uchardet-bindings"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,63 @@ resolver = "2"
 members = ["crates/*"]
 default-members = ["crates/*"]
 
+[workspace.lints.clippy]
+# Start with all lints allowed, then selectively enable groups
+all = { level = "allow", priority = -2 }
+
+# Deny lint groups
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+style = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+cargo = { level = "deny", priority = -1 }
+
+# Additional deny lints
+or_fun_call = "deny"
+
+# Allow specific noisy lints from the denied groups
+clone_on_copy = "allow"
+type_complexity = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+cast_lossless = "allow"
+too_many_lines = "allow"
+doc_markdown = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+return_self_not_must_use = "allow"
+unreadable_literal = "allow"
+struct_excessive_bools = "allow"
+similar_names = "allow"
+items_after_statements = "allow"
+wildcard_imports = "allow"
+missing_const_for_fn = "allow"
+needless_pass_by_value = "allow"
+ignored_unit_patterns = "allow"
+allow_attributes_without_reason = "allow"
+ignore_without_reason = "allow"
+non_std_lazy_statics = "allow"
+pub_underscore_fields = "allow"
+cast_precision_loss = "allow"
+struct_field_names = "allow"
+ptr_as_ptr = "allow"
+ref_as_ptr = "allow"
+used_underscore_binding = "allow"
+default_trait_access = "allow"
+match_same_arms = "allow"
+unnecessary_wraps = "allow"
+naive_bytecount = "allow"
+trivially_copy_pass_by_ref = "allow"
+large_futures = "allow"
+unused_async = "allow"
+multiple_crate_versions = "allow"
+cargo_common_metadata = "allow"
+
 #
 # Release
 #

--- a/Makefile
+++ b/Makefile
@@ -67,19 +67,7 @@ fmt: $(RUST_SOURCE)
 	cargo fmt --all -- --check
 
 clippy: $(RUST_SOURCE)
-	# cargo clippy -- -Dclippy::all -Dclippy::pedantic
-	# __CARGO_FIX_YOLO=1 cargo clippy --fix to get it to apply risky changes
-	# TODO: add -D clippy::style one day. in general add more clippy lints.
-	# __CARGO_FIX_YOLO=1 cargo clippy --workspace --all-targets --fix --allow-dirty -- \
-	cargo clippy --workspace --all-targets -- \
-		-A clippy::all \
-		-D clippy::correctness \
-		-D clippy::suspicious \
-		-D clippy::complexity \
-		-D clippy::perf \
-		-D clippy::or_fun_call \
-		-A clippy::clone-on-copy \
-		-A clippy::type-complexity
+	cargo clippy --workspace --all-targets
 
 ci: check build test fmt clippy scmscx.com-image-debug
 

--- a/crates/backblaze/Cargo.toml
+++ b/crates/backblaze/Cargo.toml
@@ -6,20 +6,23 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "*", features = ["rt-multi-thread","tracing","full"] }
-tokio-util = { version = "*", features = ["codec"] }
-anyhow = "*"
-reqwest = { version = "*", default-features = false, features = ["json", "stream", "http2", "h3", "rustls-tls"] }
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"
-bytes = "*"
-futures-core = "*"
-sha1 = "*"
-thiserror = "*"
-async-stream = "*"
-futures = "*"
-pin-project = "*"
+tokio = { version = "1.47.1", features = ["rt-multi-thread","tracing","full"] }
+tokio-util = { version = "0.7.16", features = ["codec"] }
+anyhow = "1.0.99"
+reqwest = { version = "0.12.4", default-features = false, features = ["json", "stream", "http2", "h3", "rustls-tls"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+bytes = "1.10.1"
+futures-core = "0.3.31"
+sha1 = "0.10.6"
+thiserror = "2.0.16"
+async-stream = "0.3.6"
+futures = "0.3.31"
+pin-project = "1.1.10"
 
 [dev-dependencies]
-uuid = { version = "*", features = ["v4"] }
-assert_matches = "*"
+uuid = { version = "1.18.0", features = ["v4"] }
+assert_matches = "1.5.0"
+
+[lints]
+workspace = true

--- a/crates/backblaze/src/api.rs
+++ b/crates/backblaze/src/api.rs
@@ -49,7 +49,10 @@ pub enum B2Error {
 
 impl From<B2ErrorBody> for B2Error {
     fn from(value: B2ErrorBody) -> Self {
-        use B2Error::*;
+        use B2Error::{
+            BadAuthToken, BadBucketId, BadRequest, ExpiredAuthToken, NotFound, ServiceUnavailable,
+            StorageCapExceeded, Unauthorized, Unknown,
+        };
 
         match value.code.as_str() {
             "bad_bucket_id" => BadBucketId(value.message),
@@ -168,7 +171,7 @@ pub async fn b2_download_file_by_name(
     bucket_name: &str,
     file_name: &str,
 ) -> Result<B2DownloadFileByName<impl Stream<Item = Result<Bytes, reqwest::Error>>>, B2Error> {
-    use crate::api::B2Error::*;
+    use crate::api::B2Error::Network;
 
     let response = client
         .get(format!(

--- a/crates/backblaze/src/test.rs
+++ b/crates/backblaze/src/test.rs
@@ -12,8 +12,8 @@ use reqwest::{Client, Error};
 use sha1::{Digest, Sha1};
 use std::pin::pin;
 
-const TEST_BUCKET: &'static str = "386b8f2e6e36dc507ee50d1c";
-const TEST_BUCKET_NAME: &'static str = "sventyseven-test";
+const TEST_BUCKET: &str = "386b8f2e6e36dc507ee50d1c";
+const TEST_BUCKET_NAME: &str = "sventyseven-test";
 
 async fn download_stream(stream: impl Stream<Item = Result<Bytes, Error>>) -> Result<Bytes> {
     let mut bytes = BytesMut::new();
@@ -158,7 +158,7 @@ async fn test_b2_upload_file() -> Result<(), anyhow::Error> {
         let (len, sha1_hash, stream) = prepare_stream(data);
         assert_matches!(
             b2_upload_file(&client, &upload_url, &filename, len, sha1_hash, stream).await,
-            Ok(_)
+            Ok(())
         );
     }
 

--- a/crates/bwcommon/Cargo.toml
+++ b/crates/bwcommon/Cargo.toml
@@ -11,32 +11,35 @@ bwmap = { path = "../bwmap" }
 bwmpq = { path = "../bwmpq" }
 bwminimaprender = { path = "../bwminimaprender" }
 
-actix-web = "*"
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"
-anyhow = "*"
+actix-web = "4.11.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+anyhow = "1.0.99"
 # r2d2_postgres = "*"
-image = { version = "*", default-features = false, features = ["png"] }
-reqwest = { version = "*", default-features = false, features = ["json", "stream", "blocking", "http2", "rustls-tls"] }
-uuid = { version = "*", features = ["v4"] }
-handlebars = "*"
-walkdir = "*"
-actix-multipart = "*"
-tracing = "*"
-rand = "*"
-phf = { version = "*", features = ["macros"] }
-crc = "*"
-bb8-postgres = "*"
-awc = "*"
+image = { version = "0.25.6", default-features = false, features = ["png"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["json", "stream", "blocking", "http2", "rustls-tls"] }
+uuid = { version = "1.18.0", features = ["v4"] }
+handlebars = "6.3.2"
+walkdir = "2.5.0"
+actix-multipart = "0.7.2"
+tracing = "0.1.41"
+rand = "0.9.2"
+phf = { version = "0.13.1", features = ["macros"] }
+crc = "3.3.0"
+bb8-postgres = "0.9.0"
+awc = "3.7.0"
 
-tokio = { version = "*", features = ["full"] }
-futures-util = "*"
-sha2 = "*"
+tokio = { version = "1.47.1", features = ["full"] }
+futures-util = "0.3.31"
+sha2 = "0.10.9"
 
-zstd = "*"
+zstd = "0.13.3"
 
-fnv = "*"
+fnv = "1.0.7"
 
 [dev-dependencies]
-quickcheck = "*"
-quickcheck_macros = "*"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.1.0"
+
+[lints]
+workspace = true

--- a/crates/bwcommon/src/denorm.rs
+++ b/crates/bwcommon/src/denorm.rs
@@ -48,7 +48,7 @@ pub fn calculate_perceptual_hashes(minimap: &Vec<u8>) -> Result<(Vec<u8>, Vec<u8
 
     let ph8x8: Vec<_> = ph8x8
         .iter()
-        .map(|x| if *x < ph8x8_avg { 0 } else { 1 })
+        .map(|x| u8::from(*x >= ph8x8_avg))
         .collect::<Vec<u8>>()
         .chunks_exact(8)
         .map(|x| x.iter().fold(0u8, |acc, x| (acc << 1) | *x))
@@ -57,7 +57,7 @@ pub fn calculate_perceptual_hashes(minimap: &Vec<u8>) -> Result<(Vec<u8>, Vec<u8
 
     let ph16x16: Vec<_> = ph16x16
         .iter()
-        .map(|x| if *x < ph16x16_avg { 0 } else { 1 })
+        .map(|x| u8::from(*x >= ph16x16_avg))
         .collect::<Vec<u8>>()
         .chunks_exact(8)
         .map(|x| x.iter().fold(0u8, |acc, x| (acc << 1) | *x))
@@ -66,7 +66,7 @@ pub fn calculate_perceptual_hashes(minimap: &Vec<u8>) -> Result<(Vec<u8>, Vec<u8
 
     let ph32x32: Vec<_> = ph32x32
         .iter()
-        .map(|x| if *x < ph32x32_avg { 0 } else { 1 })
+        .map(|x| u8::from(*x >= ph32x32_avg))
         .collect::<Vec<u8>>()
         .chunks_exact(8)
         .map(|x| x.iter().fold(0u8, |acc, x| (acc << 1) | *x))
@@ -84,11 +84,11 @@ async fn update_strings(
     pub(crate) fn sanitize_sc_string(s: &str) -> String {
         // split string by left or right marks
 
-        let mut strings: Vec<_> = s.split(|x| x == '\u{0012}' || x == '\u{0013}').collect();
+        let mut strings: Vec<_> = s.split(['\u{0012}', '\u{0013}']).collect();
 
         strings.sort_by_key(|x| std::cmp::Reverse(x.len()));
 
-        if strings.len() == 0 {
+        if strings.is_empty() {
             String::new()
         } else {
             strings[0].chars().filter(|&x| x >= ' ').collect()
@@ -157,22 +157,18 @@ async fn update_strings(
     let (scenario_name, scenario_description) = if let Ok(x) = &parsed_chk.sprp {
         let scenario_string = if x.scenario_name_string_number == 0 {
             None
+        } else if let Ok(s) = parsed_chk.get_string(x.scenario_name_string_number as usize) {
+            Some(sanitize_sc_string_preserve_newlines(s.as_str()))
         } else {
-            if let Ok(s) = parsed_chk.get_string(x.scenario_name_string_number as usize) {
-                Some(sanitize_sc_string_preserve_newlines(s.as_str()))
-            } else {
-                None
-            }
+            None
         };
 
         let scenario_description_string = if x.description_string_number == 0 {
             None
+        } else if let Ok(s) = parsed_chk.get_string(x.description_string_number as usize) {
+            Some(sanitize_sc_string_preserve_newlines(s.as_str()))
         } else {
-            if let Ok(s) = parsed_chk.get_string(x.description_string_number as usize) {
-                Some(sanitize_sc_string_preserve_newlines(s.as_str()))
-            } else {
-                None
-            }
+            None
         };
 
         (scenario_string, scenario_description_string)
@@ -218,7 +214,7 @@ async fn update_strings(
             ],
         )
         .await?;
-    };
+    }
 
     // unit names
     if let Some(unit_names) = unit_names {
@@ -285,10 +281,11 @@ async fn update_minimap(
     tx.execute("delete from minimap where chkhash = $1", &[&chk_hash])
         .await?;
 
-    let binstring = ph16x16
-        .iter()
-        .map(|x| format!("{x:08b}"))
-        .collect::<String>();
+    let binstring = ph16x16.iter().fold(String::new(), |mut s, x| {
+        use std::fmt::Write;
+        write!(s, "{x:08b}").unwrap();
+        s
+    });
 
     tx.execute(
         "INSERT INTO minimap
@@ -447,68 +444,67 @@ pub async fn denormalize_map_tx(map_id: i64, tx: &mut Transaction<'_>) -> Result
         .await?
         .try_get(0)?;
 
-    let chk_hash = match chk_hash {
-        Some(chk_hash) => chk_hash,
-        None => {
-            // hash didn't exist in db, download the map, try to extract it, and so on.
-            let mapblob_hash: String = tx
-                .query_one("select mapblob2 from map where map.id = $1", &[&map_id])
-                .await?
-                .try_get(0)?;
+    let chk_hash = if let Some(chk_hash) = chk_hash {
+        chk_hash
+    } else {
+        // hash didn't exist in db, download the map, try to extract it, and so on.
+        let mapblob_hash: String = tx
+            .query_one("select mapblob2 from map where map.id = $1", &[&map_id])
+            .await?
+            .try_get(0)?;
 
-            const MAPBLOB_BUCKET_NAME: &'static str = "seventyseven-mapblob";
-            let client = Client::new();
+        const MAPBLOB_BUCKET_NAME: &str = "seventyseven-mapblob";
+        let client = Client::new();
 
-            let api_info = b2_authorize_account(
-                &client,
-                &std::env::var("BACKBLAZE_KEY_ID").unwrap(),
-                &std::env::var("BACKBLAZE_APPLICATION_KEY").unwrap(),
-            )
-            .await?;
+        let api_info = b2_authorize_account(
+            &client,
+            &std::env::var("BACKBLAZE_KEY_ID").unwrap(),
+            &std::env::var("BACKBLAZE_APPLICATION_KEY").unwrap(),
+        )
+        .await?;
 
-            let mut stream = b2_download_file_by_name(
-                &client,
-                &api_info,
-                MAPBLOB_BUCKET_NAME,
-                mapblob_hash.as_str(),
-            )
-            .await?;
+        let mut stream = b2_download_file_by_name(
+            &client,
+            &api_info,
+            MAPBLOB_BUCKET_NAME,
+            mapblob_hash.as_str(),
+        )
+        .await?;
 
-            let tmp_filename = format!("/tmp/{}.scx", uuid::Uuid::new_v4().as_simple());
-            let mut file = tokio::fs::File::create(&tmp_filename).await?;
+        let tmp_filename = format!("/tmp/{}.scx", uuid::Uuid::new_v4().as_simple());
+        let mut file = tokio::fs::File::create(&tmp_filename).await?;
 
-            use futures_util::stream::StreamExt;
-            while let Some(chunk) = stream.next().await {
-                let chunk = chunk?;
-                file.write_all(&chunk).await?;
-            }
-
-            file.shutdown().await?;
-
-            drop(file);
-
-            let chk_blob = bwmpq::get_chk_from_mpq_filename(tmp_filename)?;
-
-            let chk_blob_hash = {
-                use sha2::Digest;
-                let mut hasher = sha2::Sha256::new();
-                hasher.update(&chk_blob);
-                format!("{:x}", hasher.finalize())
-            };
-
-            let chk_blob_compressed = zstd::bulk::compress(chk_blob.as_slice(), 15)?;
-
-            tx.execute("INSERT INTO chkblob (hash, ver, length, data) VALUES ($1, 1, $2, $3) ON CONFLICT DO NOTHING RETURNING Cast((xmax = 0) as boolean) AS inserted",
-        &[&chk_blob_hash, &(chk_blob.len() as i64), &chk_blob_compressed]).await?;
-
-            tx.execute(
-                "update map set chkblob = $1 where map.id = $2",
-                &[&chk_blob_hash, &map_id],
-            )
-            .await?;
-
-            chk_blob_hash
+        use futures_util::stream::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            file.write_all(&chunk).await?;
         }
+
+        file.shutdown().await?;
+
+        drop(file);
+
+        let chk_blob = bwmpq::get_chk_from_mpq_filename(tmp_filename)?;
+
+        let chk_blob_hash = {
+            use sha2::Digest;
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(&chk_blob);
+            format!("{:x}", hasher.finalize())
+        };
+
+        let chk_blob_compressed = zstd::bulk::compress(chk_blob.as_slice(), 15)?;
+
+        tx.execute("INSERT INTO chkblob (hash, ver, length, data) VALUES ($1, 1, $2, $3) ON CONFLICT DO NOTHING RETURNING Cast((xmax = 0) as boolean) AS inserted",
+    &[&chk_blob_hash, &(chk_blob.len() as i64), &chk_blob_compressed]).await?;
+
+        tx.execute(
+            "update map set chkblob = $1 where map.id = $2",
+            &[&chk_blob_hash, &map_id],
+        )
+        .await?;
+
+        chk_blob_hash
     };
 
     let chk_blob = {

--- a/crates/bwcommon/src/id.rs
+++ b/crates/bwcommon/src/id.rs
@@ -106,7 +106,7 @@ fn encode_base32(bytes: &[u8; 5]) -> String {
     ];
 
     #[rustfmt::skip]
-    let encoded = String::from_iter([
+    let encoded: String = [
         ((bytes[0] & 0b11111000) >> 3),
         ((bytes[0] & 0b00000111) << 2) |
         ((bytes[1] & 0b11000000) >> 6),
@@ -119,7 +119,7 @@ fn encode_base32(bytes: &[u8; 5]) -> String {
         ((bytes[3] & 0b00000011) << 3) |
         ((bytes[4] & 0b11100000) >> 5),
         (bytes[4] & 0b00011111),
-    ].into_iter().map(|x| CHARACTER_MAP[x as usize]));
+    ].into_iter().map(|x| CHARACTER_MAP[x as usize]).collect();
 
     encoded
 }
@@ -253,17 +253,17 @@ mod test {
         assert_eq!(
             decode_base32(&encode_base32(&input.data)).unwrap(),
             input.data
-        )
+        );
     }
 
     #[quickcheck]
     fn can_obfuscate_deobfuscate_and_get_same_data_back(input: MyStruct, seed: u8) {
-        assert_eq!(deobfuscate(obfuscate(input.data, seed), seed), input.data)
+        assert_eq!(deobfuscate(obfuscate(input.data, seed), seed), input.data);
     }
 
     #[quickcheck]
     fn convert_deconvert_and_get_same_id_back(input: i64) -> TestResult {
-        if input < 0 || input >= (1 << (32 + 3)) {
+        if !(0..(1 << (32 + 3))).contains(&input) {
             return TestResult::discard();
         }
 
@@ -277,7 +277,7 @@ mod test {
 
     #[quickcheck]
     fn get_web_id_from_db_id_and_get_same_id_back(input: i64, seed: u8) -> TestResult {
-        if input < 0 || input >= (1 << (32 + 3)) {
+        if !(0..(1 << (32 + 3))).contains(&input) {
             return TestResult::discard();
         }
 
@@ -301,7 +301,7 @@ mod test {
         }
 
         for case in [1 << 35, -1, 1 << (35 + 1), 1 << 36] {
-            assert_eq!(get_web_id_from_db_id(case, seed).is_err(), true);
+            assert!(get_web_id_from_db_id(case, seed).is_err());
         }
     }
 
@@ -309,7 +309,7 @@ mod test {
     fn web_ids_do_not_repeat_small(seed: u8) {
         let mut set = HashSet::new();
         for i in 0..10_000 {
-            assert_eq!(set.insert(get_web_id_from_db_id(i, seed).unwrap()), true);
+            assert!(set.insert(get_web_id_from_db_id(i, seed).unwrap()));
         }
     }
 
@@ -322,7 +322,7 @@ mod test {
             get_db_id_from_web_id("9z8gR5dp", 97).unwrap()
         );
 
-        assert!(false);
+        unreachable!();
     }
 
     #[test]
@@ -330,7 +330,7 @@ mod test {
     fn web_ids_do_not_repeat() {
         let mut set = HashSet::new();
         for i in 0..1_000_000_000 {
-            assert_eq!(set.insert(get_web_id_from_db_id(i, 32).unwrap()), true);
+            assert!(set.insert(get_web_id_from_db_id(i, 32).unwrap()));
         }
     }
 }

--- a/crates/bwcommon/src/logging.rs
+++ b/crates/bwcommon/src/logging.rs
@@ -57,49 +57,45 @@ pub async fn create_mixpanel_channel() -> std::sync::mpsc::Sender<serde_json::Va
                 }
             }
 
-            if events.len() > 0 {
-                if std::env::var("MIXPANEL_DISABLED").is_err() {
-                    for _ in 0..5 {
-                        let ret = client
-                            .post("https://api.mixpanel.com/import")
-                            .basic_auth(
-                                std::env::var("MIXPANEL_ACCOUNT_NAME").unwrap(),
-                                Some(std::env::var("MIXPANEL_API_KEY").unwrap()),
-                            )
-                            .query(&[
-                                ("strict", 1),
-                                (
-                                    "project_id",
-                                    std::env::var("MIXPANEL_PROJECT_ID")
-                                        .unwrap()
-                                        .parse()
-                                        .unwrap(),
-                                ),
-                            ])
-                            .json(&events)
-                            .send()
-                            .await;
+            if !events.is_empty() && std::env::var("MIXPANEL_DISABLED").is_err() {
+                for _ in 0..5 {
+                    let ret = client
+                        .post("https://api.mixpanel.com/import")
+                        .basic_auth(
+                            std::env::var("MIXPANEL_ACCOUNT_NAME").unwrap(),
+                            Some(std::env::var("MIXPANEL_API_KEY").unwrap()),
+                        )
+                        .query(&[
+                            ("strict", 1),
+                            (
+                                "project_id",
+                                std::env::var("MIXPANEL_PROJECT_ID")
+                                    .unwrap()
+                                    .parse()
+                                    .unwrap(),
+                            ),
+                        ])
+                        .json(&events)
+                        .send()
+                        .await;
 
-                        match ret {
-                            Ok(ret) => match ret.status() {
-                                StatusCode::OK => {
-                                    break;
-                                }
-                                _ => {
-                                    error!(
-                                        "error from mixpanel. status: {}, body: {}",
-                                        ret.status(),
-                                        ret.text()
-                                            .await
-                                            .unwrap_or_else(|_| "failed to unwrap body".to_string())
-                                    );
-                                    sleep(std::time::Duration::from_secs(5)).await;
-                                }
-                            },
-                            Err(err) => {
-                                error!("error sending stuff to mixpanel: {err:?}");
-                                sleep(std::time::Duration::from_secs(5)).await;
+                    match ret {
+                        Ok(ret) => {
+                            if ret.status() == StatusCode::OK {
+                                break;
                             }
+                            error!(
+                                "error from mixpanel. status: {}, body: {}",
+                                ret.status(),
+                                ret.text()
+                                    .await
+                                    .unwrap_or_else(|_| "failed to unwrap body".to_string())
+                            );
+                            sleep(std::time::Duration::from_secs(5)).await;
+                        }
+                        Err(err) => {
+                            error!("error sending stuff to mixpanel: {err:?}");
+                            sleep(std::time::Duration::from_secs(5)).await;
                         }
                     }
                 }
@@ -180,42 +176,38 @@ pub struct TrackingAnalytics {
 }
 
 pub fn get_request_logging_info(req: &actix_web::HttpRequest) -> ApiRequestLoggingInfo {
-    let ip = match req.connection_info().realip_remote_addr() {
-        Some(ip) => Some(ip.to_string()),
-        None => None,
-    };
+    let ip = req
+        .connection_info()
+        .realip_remote_addr()
+        .map(std::string::ToString::to_string);
 
-    let query = match req.uri().query() {
-        Some(query) => Some(query.to_string()),
-        None => None,
-    };
+    let query = req.uri().query().map(std::string::ToString::to_string);
 
-    let tac = match req.extensions().get::<TrackingAnalytics>() {
-        Some(tac) => Some(tac.tracking_analytics_id.clone()),
-        None => None,
-    };
+    let tac = req
+        .extensions()
+        .get::<TrackingAnalytics>()
+        .map(|tac| tac.tracking_analytics_id.clone());
 
     ApiRequestLoggingInfo {
         ip,
         tac,
-        event: Some(
-            req.match_pattern()
-                .map(|x| {
-                    if x.is_empty() {
-                        req.path().to_owned()
-                    } else {
-                        x
-                    }
-                })
-                .unwrap_or_else(|| req.path().to_owned()),
-        ),
+        event: Some(req.match_pattern().map_or_else(
+            || req.path().to_owned(),
+            |x| {
+                if x.is_empty() {
+                    req.path().to_owned()
+                } else {
+                    x
+                }
+            },
+        )),
         method: req.method().to_string(),
         path: req.uri().path().to_string(),
         query,
-        referer: get_header(&req, "referer").to_string(),
-        accept_language: get_header(&req, "accept-language").to_string(),
-        accept_encoding: get_header(&req, "accept-encoding").to_string(),
-        user_agent: get_header(&req, "user-agent").to_string(),
+        referer: get_header(req, "referer").to_string(),
+        accept_language: get_header(req, "accept-language").to_string(),
+        accept_encoding: get_header(req, "accept-encoding").to_string(),
+        user_agent: get_header(req, "user-agent").to_string(),
     }
 }
 

--- a/crates/bwmap/Cargo.toml
+++ b/crates/bwmap/Cargo.toml
@@ -12,21 +12,24 @@ full = []
 uchardet-bindings = { path = "../uchardet-bindings", optional = true }
 compact_enc_det-bindings = { path = "../compact_enc_det-bindings", optional = true }
 
-serde = { version = "*", features = ["derive"] }
-encoding_rs = "*"
-anyhow = { version = "*", features = ["backtrace"] }
+serde = { version = "1.0.219", features = ["derive"] }
+encoding_rs = "0.8.35"
+anyhow = { version = "1.0.99", features = ["backtrace"] }
 
-scopeguard = "*"
-phf = { version = "0.10", features = ["macros"] }
+scopeguard = "1.2.0"
+phf = { version = "0.10.1", features = ["macros"] }
 
-tracing = "*"
+tracing = "0.1.41"
 
 
 [dev-dependencies]
 
-reqwest = { version = "*", default-features = false, features = ["json", "http2", "rustls-tls"] }
-tokio = { version = "1", features = ["full"] }
-futures = { version = "*" }
-sha2 = "*"
+reqwest = { version = "0.12.4", default-features = false, features = ["json", "http2", "rustls-tls"] }
+tokio = { version = "1.47.1", features = ["full"] }
+futures = { version = "0.3.31" }
+sha2 = "0.10.9"
 
-async-stream = "*"
+async-stream = "0.3.6"
+
+[lints]
+workspace = true

--- a/crates/bwmap/src/chk/chk_dd2.rs
+++ b/crates/bwmap/src/chk/chk_dd2.rs
@@ -36,6 +36,6 @@ pub(crate) fn parse_dd2(chunks: &[RiffChunk]) -> Result<ChkDd2, anyhow::Error> {
     let mut slicer = CursorSlicer::new(chunks[chunks.len() - 1].data);
 
     Ok(ChkDd2 {
-        doodads: slicer.extract_rest_as_slice_lax()?.to_vec(),
+        doodads: slicer.extract_rest_as_slice_lax()?.clone(),
     })
 }

--- a/crates/bwmap/src/parsed_chk.rs
+++ b/crates/bwmap/src/parsed_chk.rs
@@ -157,47 +157,47 @@ impl ParsedChk {
 
         #[rustfmt::skip]
         let ret = ParsedChk {
-            colr: riff_chunks.get(&ChunkName::COLR).map(|x| parse_colr(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            crgb: riff_chunks.get(&ChunkName::CRGB).map(|x| parse_crgb(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            dd2:  riff_chunks.get(&ChunkName::DD2 ).map(|x| parse_dd2 (x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            dim:  riff_chunks.get(&ChunkName::DIM ).map(|x| parse_dim (x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            era:  riff_chunks.get(&ChunkName::ERA ).map(|x| parse_era (x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            forc: riff_chunks.get(&ChunkName::FORC).map(|x| parse_forc(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            iown: riff_chunks.get(&ChunkName::IOWN).map(|x| parse_iown(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            isom: riff_chunks.get(&ChunkName::ISOM).map(|x| parse_isom(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            ive2: riff_chunks.get(&ChunkName::IVE2).map(|x| parse_ive2(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            iver: riff_chunks.get(&ChunkName::IVER).map(|x| parse_iver(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            mask: riff_chunks.get(&ChunkName::MASK).map(|x| parse_mask(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            mbrf: riff_chunks.get(&ChunkName::MBRF).map(|x| parse_mbrf(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            mrgn: riff_chunks.get(&ChunkName::MRGN).map(|x| parse_mrgn(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            mtxm: riff_chunks.get(&ChunkName::MTXM).map(|x| parse_mtxm(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            ownr: riff_chunks.get(&ChunkName::OWNR).map(|x| parse_ownr(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            ptec: riff_chunks.get(&ChunkName::PTEC).map(|x| parse_ptec(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            ptex: riff_chunks.get(&ChunkName::PTEx).map(|x| parse_ptex(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            puni: riff_chunks.get(&ChunkName::PUNI).map(|x| parse_puni(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            pupx: riff_chunks.get(&ChunkName::PUPx).map(|x| parse_pupx(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            side: riff_chunks.get(&ChunkName::SIDE).map(|x| parse_side(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            sprp: riff_chunks.get(&ChunkName::SPRP).map(|x| parse_sprp(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            str:  riff_chunks.get(&ChunkName::STR ).map(|x| parse_str (x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            strx: riff_chunks.get(&ChunkName::STRx).map(|x| parse_strx(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            swnm: riff_chunks.get(&ChunkName::SWNM).map(|x| parse_swnm(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            tecs: riff_chunks.get(&ChunkName::TECS).map(|x| parse_tecs(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            tecx: riff_chunks.get(&ChunkName::TECx).map(|x| parse_tecx(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            thg2: riff_chunks.get(&ChunkName::THG2).map(|x| parse_thg2(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            tile: riff_chunks.get(&ChunkName::TILE).map(|x| parse_tile(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            trig: riff_chunks.get(&ChunkName::TRIG).map(|x| parse_trig(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            type_:riff_chunks.get(&ChunkName::TYPE).map(|x| parse_type(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            unis: riff_chunks.get(&ChunkName::UNIS).map(|x| parse_unis(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            unit: riff_chunks.get(&ChunkName::UNIT).map(|x| parse_unit(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            unix: riff_chunks.get(&ChunkName::UNIx).map(|x| parse_unix(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            upgr: riff_chunks.get(&ChunkName::UPGR).map(|x| parse_upgr(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            upgs: riff_chunks.get(&ChunkName::UPGS).map(|x| parse_upgs(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            upgx: riff_chunks.get(&ChunkName::UPGx).map(|x| parse_upgx(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            uprp: riff_chunks.get(&ChunkName::UPRP).map(|x| parse_uprp(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            upus: riff_chunks.get(&ChunkName::UPUS).map(|x| parse_upus(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            vcod: riff_chunks.get(&ChunkName::VCOD).map(|x| parse_vcod(x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            ver:  riff_chunks.get(&ChunkName::VER ).map(|x| parse_ver (x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
-            wav:  riff_chunks.get(&ChunkName::WAV ).map(|x| parse_wav (x.as_slice())).unwrap_or(Err(anyhow::anyhow!("Not Found"))),
+            colr: riff_chunks.get(&ChunkName::COLR).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_colr(x.as_slice())),
+            crgb: riff_chunks.get(&ChunkName::CRGB).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_crgb(x.as_slice())),
+            dd2:  riff_chunks.get(&ChunkName::DD2 ).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_dd2 (x.as_slice())),
+            dim:  riff_chunks.get(&ChunkName::DIM ).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_dim (x.as_slice())),
+            era:  riff_chunks.get(&ChunkName::ERA ).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_era (x.as_slice())),
+            forc: riff_chunks.get(&ChunkName::FORC).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_forc(x.as_slice())),
+            iown: riff_chunks.get(&ChunkName::IOWN).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_iown(x.as_slice())),
+            isom: riff_chunks.get(&ChunkName::ISOM).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_isom(x.as_slice())),
+            ive2: riff_chunks.get(&ChunkName::IVE2).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_ive2(x.as_slice())),
+            iver: riff_chunks.get(&ChunkName::IVER).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_iver(x.as_slice())),
+            mask: riff_chunks.get(&ChunkName::MASK).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_mask(x.as_slice())),
+            mbrf: riff_chunks.get(&ChunkName::MBRF).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_mbrf(x.as_slice())),
+            mrgn: riff_chunks.get(&ChunkName::MRGN).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_mrgn(x.as_slice())),
+            mtxm: riff_chunks.get(&ChunkName::MTXM).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_mtxm(x.as_slice())),
+            ownr: riff_chunks.get(&ChunkName::OWNR).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_ownr(x.as_slice())),
+            ptec: riff_chunks.get(&ChunkName::PTEC).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_ptec(x.as_slice())),
+            ptex: riff_chunks.get(&ChunkName::PTEx).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_ptex(x.as_slice())),
+            puni: riff_chunks.get(&ChunkName::PUNI).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_puni(x.as_slice())),
+            pupx: riff_chunks.get(&ChunkName::PUPx).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_pupx(x.as_slice())),
+            side: riff_chunks.get(&ChunkName::SIDE).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_side(x.as_slice())),
+            sprp: riff_chunks.get(&ChunkName::SPRP).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_sprp(x.as_slice())),
+            str:  riff_chunks.get(&ChunkName::STR ).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_str (x.as_slice())),
+            strx: riff_chunks.get(&ChunkName::STRx).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_strx(x.as_slice())),
+            swnm: riff_chunks.get(&ChunkName::SWNM).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_swnm(x.as_slice())),
+            tecs: riff_chunks.get(&ChunkName::TECS).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_tecs(x.as_slice())),
+            tecx: riff_chunks.get(&ChunkName::TECx).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_tecx(x.as_slice())),
+            thg2: riff_chunks.get(&ChunkName::THG2).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_thg2(x.as_slice())),
+            tile: riff_chunks.get(&ChunkName::TILE).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_tile(x.as_slice())),
+            trig: riff_chunks.get(&ChunkName::TRIG).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_trig(x.as_slice())),
+            type_:riff_chunks.get(&ChunkName::TYPE).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_type(x.as_slice())),
+            unis: riff_chunks.get(&ChunkName::UNIS).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_unis(x.as_slice())),
+            unit: riff_chunks.get(&ChunkName::UNIT).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_unit(x.as_slice())),
+            unix: riff_chunks.get(&ChunkName::UNIx).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_unix(x.as_slice())),
+            upgr: riff_chunks.get(&ChunkName::UPGR).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_upgr(x.as_slice())),
+            upgs: riff_chunks.get(&ChunkName::UPGS).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_upgs(x.as_slice())),
+            upgx: riff_chunks.get(&ChunkName::UPGx).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_upgx(x.as_slice())),
+            uprp: riff_chunks.get(&ChunkName::UPRP).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_uprp(x.as_slice())),
+            upus: riff_chunks.get(&ChunkName::UPUS).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_upus(x.as_slice())),
+            vcod: riff_chunks.get(&ChunkName::VCOD).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_vcod(x.as_slice())),
+            ver:  riff_chunks.get(&ChunkName::VER ).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_ver (x.as_slice())),
+            wav:  riff_chunks.get(&ChunkName::WAV ).map_or(Err(anyhow::anyhow!("Not Found")), |x| parse_wav (x.as_slice())),
         };
 
         ret
@@ -254,7 +254,7 @@ impl ParsedChk {
             }
 
             let str_offset: usize =
-                u16::from_le_bytes(x.string_data[offset..offset + 2].try_into()?).try_into()?;
+                u16::from_le_bytes(x.string_data[offset..offset + 2].try_into()?).into();
 
             if str_offset >= x.string_data.len() {
                 return Ok(format!(
@@ -269,7 +269,7 @@ impl ParsedChk {
         };
 
         if bytes.is_empty() {
-            return Ok("".to_owned());
+            return Ok(String::new());
         }
 
         let mut euc_kr_failed = false;
@@ -326,7 +326,7 @@ impl ParsedChk {
             // filter out color codes because it might be breaking uchardet.
             let vec: Vec<_> = bytes.iter().filter(|&&x| x >= 0x20).copied().collect();
 
-            if uchardet_bindings::uchardet_handle_data(handle, vec.as_ptr() as *const i8, vec.len())
+            if uchardet_bindings::uchardet_handle_data(handle, vec.as_ptr().cast::<i8>(), vec.len())
                 != 0
             {
                 panic!();
@@ -363,7 +363,7 @@ impl ParsedChk {
             let mut is_reliable = false;
 
             let encoding = compact_enc_det_bindings::CompactEncDet_DetectEncoding(
-                vec.as_ptr() as *const i8,
+                vec.as_ptr().cast::<i8>(),
                 vec.len() as i32,
                 std::ptr::null::<i8>(),
                 std::ptr::null::<i8>(),
@@ -372,8 +372,8 @@ impl ParsedChk {
                 compact_enc_det_bindings::Language_UNKNOWN_LANGUAGE,
                 compact_enc_det_bindings::CompactEncDet_TextCorpusType_WEB_CORPUS,
                 true,
-                &mut bytes_consumed,
-                &mut is_reliable,
+                &raw mut bytes_consumed,
+                &raw mut is_reliable,
             );
 
             // println!("is_reliable: {is_reliable}, bytes_consumed: {bytes_consumed}");
@@ -549,7 +549,7 @@ impl ParsedChk {
             }
 
             if mrgn.locations[index - 1].name_string_number == 0 {
-                Ok(format!("Location {} has a string name index of 0", index))
+                Ok(format!("Location {index} has a string name index of 0"))
             } else {
                 self.get_string(mrgn.locations[index - 1].name_string_number as usize)
             }

--- a/crates/bwmap/src/riff.rs
+++ b/crates/bwmap/src/riff.rs
@@ -110,7 +110,7 @@ mod test {
         while let Some(chk) = stream.try_next().await.unwrap() {
             let riff_chunks = parse_riff(&chk);
 
-            assert!(riff_chunks.len() > 0);
+            assert!(!riff_chunks.is_empty());
             assert!(riff_chunks
                 .iter()
                 .any(|x| std::mem::discriminant(&x.chunk_name)

--- a/crates/bwmap/src/test/base.rs
+++ b/crates/bwmap/src/test/base.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::if_same_then_else, clippy::bool_to_int_with_if)]
 use crate::{
     chk::{
         chk_mbrf::{ChkMbrfAction, ChkMbrfCondition, ChkMbrfIndividual},
@@ -659,7 +660,7 @@ async fn test_specific_map_files_for_known_values() {
                     },
                     "{x:?}"
                 ),
-            };
+            }
         }
     } else {
         unreachable!();

--- a/crates/bwmap/src/test/bw.rs
+++ b/crates/bwmap/src/test/bw.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::if_same_then_else, clippy::bool_to_int_with_if)]
 use crate::{
     chk::{
         chk_mbrf::{ChkMbrfAction, ChkMbrfCondition, ChkMbrfIndividual},
@@ -658,7 +659,7 @@ async fn test_specific_map_files_for_known_values() {
                     },
                     "{x:?}"
                 ),
-            };
+            }
         }
     }
 

--- a/crates/bwmap/src/test/bwremaster.rs
+++ b/crates/bwmap/src/test/bwremaster.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::if_same_then_else, clippy::bool_to_int_with_if)]
 use crate::{
     chk::{
         chk_mbrf::{ChkMbrfAction, ChkMbrfCondition, ChkMbrfIndividual},
@@ -658,7 +659,7 @@ async fn test_specific_map_files_for_known_values() {
                     },
                     "{x:?}"
                 ),
-            };
+            }
         }
     }
 

--- a/crates/bwmap/src/test/general.rs
+++ b/crates/bwmap/src/test/general.rs
@@ -98,7 +98,7 @@ async fn test_constrain_encoding_detection_algorithm() {
         parsed_chk
             .get_string(sprp_scenario_index as usize)
             .unwrap()
-            .to_owned()
+            .clone()
     };
 
     #[rustfmt::skip]
@@ -115,7 +115,7 @@ async fn test_constrain_encoding_detection_algorithm() {
         ("d3e7310b02fc5f296299b6dd6c22f9850db879407f39c8244cb794a385505fa3", "\u{3}Marine Special Forces \u{7}Re"),
     ];
 
-    for (a, b) in test_vectors.into_iter() {
+    for (a, b) in test_vectors {
         assert_eq!(b, f(a.to_owned()).await);
     }
 }
@@ -144,7 +144,7 @@ async fn test_constrain_encoding_detection_algorithm2() {
         ("7e887e2b72a146becbdfa4832d30e1adbde9c9ed3ebe5294def6c8dda4232522", 6,  "Snow 3.5 정식버전"),
     ];
 
-    for (a, b, c) in test_vectors.into_iter() {
+    for (a, b, c) in test_vectors {
         assert_eq!(c, f(a.to_owned(), b).await);
     }
 }

--- a/crates/bwmap/src/test/hybrid.rs
+++ b/crates/bwmap/src/test/hybrid.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::if_same_then_else, clippy::bool_to_int_with_if)]
 use super::get_chk;
 use crate::{
     chk::{
@@ -658,7 +659,7 @@ async fn test_specific_map_files_for_known_values() {
                     },
                     "{x:?}"
                 ),
-            };
+            }
         }
     }
 

--- a/crates/bwmap/src/test/remasterhybrid.rs
+++ b/crates/bwmap/src/test/remasterhybrid.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::if_same_then_else, clippy::bool_to_int_with_if)]
 use crate::{
     chk::{
         chk_mbrf::{ChkMbrfAction, ChkMbrfCondition, ChkMbrfIndividual},
@@ -658,7 +659,7 @@ async fn test_specific_map_files_for_known_values() {
                     },
                     "{x:?}"
                 ),
-            };
+            }
         }
     }
 

--- a/crates/bwmap/src/test/util.rs
+++ b/crates/bwmap/src/test/util.rs
@@ -31,20 +31,16 @@ pub async fn get_chk(chk_hash: &str) -> Result<Vec<u8>> {
     tokio::fs::create_dir_all(&dir).await.unwrap();
     let path = dir.join(chk_hash);
 
-    match tokio::fs::read(&path).await {
-        Ok(data) => {
-            if hash(data.as_slice()) != chk_hash {
-            } else {
-                return anyhow::Ok(data);
-            }
+    if let Ok(data) = tokio::fs::read(&path).await {
+        if hash(data.as_slice()) == chk_hash {
+            return anyhow::Ok(data);
         }
-        Err(_) => {}
     }
 
-    let url = format!("https://scmscx.com/api/chk/{}", chk_hash);
+    let url = format!("https://scmscx.com/api/chk/{chk_hash}");
     let bytes = reqwest::get(url).await.unwrap().bytes().await.unwrap();
 
-    assert!(bytes.len() > 0);
+    assert!(!bytes.is_empty());
     assert_eq!(hash(&bytes[..]), chk_hash);
 
     tokio::fs::write(&path, &bytes[..]).await.unwrap();

--- a/crates/bwmap/src/trig.rs
+++ b/crates/bwmap/src/trig.rs
@@ -486,7 +486,7 @@ fn parse_ai_script(aiscript_id: u32) -> &'static str {
     if let Ok(x) = reinterpret_as_slice(&aiscript_id) {
         AI_SCRIPT_MAP
             .get(x)
-            .cloned()
+            .copied()
             .unwrap_or("Failed to find ai script")
     } else {
         ""

--- a/crates/bwmap/src/util.rs
+++ b/crates/bwmap/src/util.rs
@@ -3,15 +3,14 @@ use tracing::instrument;
 
 #[instrument(level = "trace", skip_all)]
 pub(crate) fn parse_slice<T: Copy>(s: &[u8]) -> T {
-    if std::mem::size_of::<T>() != s.len() {
-        panic!(
-            "sizeof<t>: {}, s.len(): {}",
-            std::mem::size_of::<T>(),
-            s.len()
-        );
-    }
+    assert!(
+        std::mem::size_of::<T>() == s.len(),
+        "sizeof<t>: {}, s.len(): {}",
+        std::mem::size_of::<T>(),
+        s.len()
+    );
 
-    unsafe { std::ptr::read_unaligned(s.as_ptr() as *const T) }
+    unsafe { std::ptr::read_unaligned(s.as_ptr().cast::<T>()) }
 }
 
 // pub(crate) fn parse_slice2<T: Copy>(s: &mut std::io::Cursor<&[u8]>) -> Result<T, anyhow::Error> {
@@ -46,7 +45,10 @@ pub(crate) fn parse_slice<T: Copy>(s: &[u8]) -> T {
 #[cfg(feature = "full")]
 pub(crate) fn reinterpret_as_slice<T: Sized + Copy>(s: &T) -> Result<&[u8], anyhow::Error> {
     anyhow::Ok(unsafe {
-        std::slice::from_raw_parts((s as *const T) as *const u8, std::mem::size_of::<T>())
+        std::slice::from_raw_parts(
+            std::ptr::from_ref::<T>(s).cast::<u8>(),
+            std::mem::size_of::<T>(),
+        )
     })
 }
 
@@ -64,7 +66,7 @@ pub(crate) fn reinterpret_slice2<T: Sized + Copy>(s: &[u8]) -> Result<Vec<T>, an
     for i in 0..count {
         unsafe {
             result.push(std::ptr::read_unaligned(
-                s.as_ptr().add(i * std::mem::size_of::<T>()) as *const T,
+                s.as_ptr().add(i * std::mem::size_of::<T>()).cast::<T>(),
             ));
         }
     }
@@ -220,7 +222,7 @@ impl<'a> CursorSlicer<'a> {
         anyhow::ensure!(self.s.len() >= self.current_offset + std::mem::size_of::<T>());
 
         let ret =
-            unsafe { std::ptr::read_unaligned(self.s[self.current_offset..].as_ptr() as *const T) };
+            unsafe { std::ptr::read_unaligned(self.s[self.current_offset..].as_ptr().cast::<T>()) };
         self.current_offset += std::mem::size_of::<T>();
         Ok(ret)
     }

--- a/crates/bwmapserver/Cargo.toml
+++ b/crates/bwmapserver/Cargo.toml
@@ -13,74 +13,74 @@ backblaze = { path = "../backblaze" }
 bwminimaprender = { path = "../bwminimaprender" }
 bwmpq = { path = "../bwmpq" }
 
-cached = { version = "*", features = ["async", "proc_macro"] }
+cached = { version = "0.56.0", features = ["async", "proc_macro"] }
 
 #itertools = "*"
-base64 = "*"
-handlebars = { version = "*", features = ["dir_source"] }
-lazy_static = "*"
+base64 = "0.22.1"
+handlebars = { version = "6.3.2", features = ["dir_source"] }
+lazy_static = "1.5.0"
 #lru = "*"
 # rusqlite = "0.24.2"
 # rocket = { version = "" }
 # rocket_contrib = ""
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"
-tokio-util = { version = "*", features = ["codec"] }
-tokio = { version = "*", features = ["rt-multi-thread","tracing","full"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+tokio-util = { version = "0.7.16", features = ["codec"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread","tracing","full"] }
 #tokio = { version = "*", features = ["rt-multi-thread"] }
 #console-subscriber = "*"
-sha2 = "*"
-sha1 = "*"
+sha2 = "0.10.9"
+sha1 = "0.10.6"
 # tempfile = "*"
 # url = "*"
-encoding_rs = "*"
+encoding_rs = "0.8.35"
 # widestring = ""
-walkdir = "*"
+walkdir = "2.5.0"
 # slog = ""
 # sloggers = ""
 # rocket-slog = ""
-image = { version = "*", default-features = false, features = ["png"] }
+image = { version = "0.25.6", default-features = false, features = ["png"] }
 # png = { version = "*", optional = true }
 # nude = ""
-regex = "*"
-anyhow = "*"
-actix-web = { version = "*", features = ["rustls"] }
-actix-proxy = "*"
-awc = "*"
+regex = "1.11.2"
+anyhow = "1.0.99"
+actix-web = { version = "4.11.0", features = ["rustls"] }
+actix-proxy = "0.2.0"
+awc = "3.7.0"
 # actix-http = "*"
 # actix-session = ""
-actix-files = "*"
+actix-files = "0.6.7"
 # actix-service = "*"
 # actix-rt = "*"
-actix-multipart = "*"
+actix-multipart = "0.7.2"
 #env_logger = "*"
 #mime = "*"
 # time = "0.2.27"
-reqwest = { version = "*", default-features = false, features = ["json", "stream", "http2", "h3", "rustls-tls"] }
-futures-core = "*"
-futures-util = "*"
-bytes = "*"
-async-stream = "*"
+reqwest = { version = "0.12.4", default-features = false, features = ["json", "stream", "http2", "h3", "rustls-tls"] }
+futures-core = "0.3.31"
+futures-util = "0.3.31"
+bytes = "1.10.1"
+async-stream = "0.3.6"
 
 # actix-web-middleware-redirect-scheme = ""
-futures = "*"
+futures = "0.3.31"
 # reqwest = "*"
-uuid = { version = "*", features = ["v4"] }
+uuid = { version = "1.18.0", features = ["v4"] }
 # r2d2 = "*"
 # r2d2_sqlite = ""
 # r2d2_postgres = "*"
-bb8-postgres = "*"
+bb8-postgres = "0.9.0"
 # bitreader = ""
 # flate2 = "*"
 # hex = "*"
-zstd = "*"
+zstd = "0.13.3"
 
-log = "*"
-tracing = "*"
-tracing-subscriber = { version = "*", features = ["registry", "env-filter"] }
-tracing-log = "*"
+log = "0.4.27"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["registry", "env-filter"] }
+tracing-log = "0.2.0"
 
-rand = "*"
+rand = "0.9.2"
 
 [dev-dependencies]
 
@@ -96,3 +96,6 @@ rand = "*"
 #  ├─── "rocket_contrib"
 #  ├─── "slog"
 #  └─── "sloggers"
+
+[lints]
+workspace = true

--- a/crates/bwmapserver/src/actix.rs
+++ b/crates/bwmapserver/src/actix.rs
@@ -66,7 +66,7 @@ pub async fn get_auth(
     if lock.auth.is_none() || reacquire {
         lock.auth = Some(
             b2_authorize_account(
-                &client,
+                client,
                 &std::env::var("BACKBLAZE_KEY_ID").unwrap(),
                 &std::env::var("BACKBLAZE_APPLICATION_KEY").unwrap(),
             )
@@ -119,7 +119,7 @@ async fn get_map(
         }
     }
 
-    const MAPBLOB_BUCKET_NAME: &'static str = "seventyseven-mapblob";
+    const MAPBLOB_BUCKET_NAME: &str = "seventyseven-mapblob";
     let client = Client::new();
 
     let mut retries_remaining = 5;
@@ -206,7 +206,7 @@ async fn get_map(
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 
-    return Ok(insert_extension(HttpResponse::InternalServerError(), info).finish());
+    Ok(insert_extension(HttpResponse::InternalServerError(), info).finish())
 }
 
 #[get("/api/replays/{replay_id}")]
@@ -247,7 +247,7 @@ async fn recent_activity(
         let conn = pool.get().await?;
         let mut v = Vec::new();
 
-        for row in conn
+        for row in &conn
             .query(
                 "
                 select replay.id, denorm_scenario, account.username, replay.uploaded_time
@@ -259,7 +259,6 @@ async fn recent_activity(
                 &[],
             )
             .await?
-            .iter()
         {
             v.push((
                 row.try_get::<_, i64>(0)?,
@@ -279,7 +278,7 @@ async fn recent_activity(
         let mut v = Vec::new();
         let conn = pool.get().await?;
 
-        for row in conn
+        for row in &conn
             .query(
                 "
             select map.id, denorm_scenario, account.username, uploaded_time
@@ -291,7 +290,6 @@ async fn recent_activity(
                 &[],
             )
             .await?
-            .iter()
         {
             v.push((
                 bwcommon::get_web_id_from_db_id(
@@ -650,7 +648,7 @@ async fn get_tags(
         .collect::<Result<Vec<_>, _>>()?;
 
     let info = ApiSpecificInfoForLogging {
-        user_id: user_id,
+        user_id,
         map_id: Some(map_id),
         ..Default::default()
     };
@@ -677,9 +675,7 @@ async fn set_tags(
         bwcommon::get_db_id_from_web_id(&map_id, crate::util::SEED_MAP_ID)?
     };
 
-    let user_id = if let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? {
-        user_id
-    } else {
+    let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? else {
         return Ok(HttpResponse::Unauthorized().finish());
     };
 
@@ -719,9 +715,7 @@ async fn add_tags(
         bwcommon::get_db_id_from_web_id(&map_id, crate::util::SEED_MAP_ID)?
     };
 
-    let user_id = if let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? {
-        user_id
-    } else {
+    let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? else {
         return Ok(HttpResponse::Unauthorized().finish());
     };
 
@@ -750,18 +744,18 @@ fn parse_lst_files() -> std::collections::HashMap<u32, std::collections::HashMap
 
         for result in reader.lines() {
             let line: String = result.unwrap();
-            if line.len() == 0 {
+            if line.is_empty() {
                 continue;
             }
 
-            let split: Vec<&str> = line.split("\t").collect();
+            let split: Vec<&str> = line.split('\t').collect();
 
             if split.len() != 5 {
                 continue;
             }
 
             let id = split[0].parse::<u16>().unwrap();
-            let rgb: Vec<u8> = (&split[1][1..split[1].len() - 1])
+            let rgb: Vec<u8> = split[1][1..split[1].len() - 1]
                 .split(',')
                 .map(|x| x.parse::<u8>().unwrap())
                 .collect();
@@ -844,7 +838,7 @@ fn register_handlebars() -> Result<web::Data<Handlebars<'static>>> {
     }
 
     let mut options = DirectorySourceOptions::default();
-    options.tpl_extension = ".hbs".to_owned();
+    ".hbs".clone_into(&mut options.tpl_extension);
     registry
         .register_templates_directory(
             std::path::Path::new(std::env::var("ROOT_DIR").unwrap().as_str()).join("uiv2"),
@@ -1077,13 +1071,12 @@ pub(crate) async fn start() -> Result<()> {
                 |req: HttpRequest, client: web::Data<awc::Client>| async move {
                     use actix_proxy::IntoHttpResponse;
 
-                    let path_query = req
-                        .uri()
-                        .path_and_query()
-                        .map(|v| v.as_str())
-                        .unwrap_or_else(|| req.uri().path());
+                    let path_query = req.uri().path_and_query().map_or_else(
+                        || req.uri().path(),
+                        actix_web::http::uri::PathAndQuery::as_str,
+                    );
 
-                    let url = format!("http://localhost:3000{}", path_query);
+                    let url = format!("http://localhost:3000{path_query}");
 
                     info!("proxying to {}", url);
 

--- a/crates/bwmapserver/src/api/bulkupload.rs
+++ b/crates/bwmapserver/src/api/bulkupload.rs
@@ -32,9 +32,7 @@ pub(crate) async fn insert_map(
         format!("{:x}", hasher.finalize())
     };
 
-    let sprp_section = if let Ok(x) = &parsed_chk.sprp {
-        x
-    } else {
+    let Ok(sprp_section) = &parsed_chk.sprp else {
         return Err(parsed_chk.sprp.unwrap_err());
     };
 
@@ -177,11 +175,11 @@ pub(crate) async fn insert_map(
 fn sanitize_sc_scenario_string(s: &str) -> String {
     // split string by left or right marks
 
-    let mut strings: Vec<_> = s.split(|x| x == '\u{0012}' || x == '\u{0013}').collect();
+    let mut strings: Vec<_> = s.split(['\u{0012}', '\u{0013}']).collect();
 
     strings.sort_by_key(|x| std::cmp::Reverse(x.len()));
 
-    if strings.len() == 0 {
+    if strings.is_empty() {
         String::new()
     } else {
         strings[0].to_string()

--- a/crates/bwmapserver/src/api/change_password.rs
+++ b/crates/bwmapserver/src/api/change_password.rs
@@ -15,9 +15,7 @@ async fn handler2(
         >,
     >,
 ) -> Result<HttpResponse, bwcommon::MyError> {
-    let user_id = if let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? {
-        user_id
-    } else {
+    let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? else {
         return Ok(HttpResponse::Unauthorized().body("Unauthorized. Try logging in first/again."));
     };
 
@@ -25,7 +23,7 @@ async fn handler2(
         return Ok(HttpResponse::BadRequest().body("The two provided passwords must match"));
     }
 
-    if form.password.len() < 1 {
+    if form.password.is_empty() {
         return Ok(
             HttpResponse::BadRequest().body("The provided password must not be the empty string")
         );

--- a/crates/bwmapserver/src/api/change_username.rs
+++ b/crates/bwmapserver/src/api/change_username.rs
@@ -16,13 +16,11 @@ async fn handler2(
         >,
     >,
 ) -> Result<HttpResponse, bwcommon::MyError> {
-    let user_id = if let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? {
-        user_id
-    } else {
+    let Some(user_id) = bwcommon::check_auth4(&req, (**pool).clone()).await? else {
         return Ok(HttpResponse::Unauthorized().body("Unauthorized. Try logging in first/again."));
     };
 
-    if form.username.len() < 1 {
+    if form.username.is_empty() {
         return Ok(
             HttpResponse::BadRequest().body("The provided username must not be the empty string")
         );

--- a/crates/bwmapserver/src/api/flags.rs
+++ b/crates/bwmapserver/src/api/flags.rs
@@ -37,7 +37,7 @@ async fn get_flag(
     let checked: bool = con.query_one(statement, &[&map_id]).await?.try_get(0)?;
 
     let info = ApiSpecificInfoForLogging {
-        user_id: user_id,
+        user_id,
         map_id: Some(map_id),
         ..Default::default()
     };
@@ -59,9 +59,7 @@ async fn set_flag(
             .body("server is in maintenance mode, try again later.".to_owned()));
     }
 
-    let user_id = if let Some(user_id) = req.extensions().get::<UserSession>().map(|x| x.id) {
-        user_id
-    } else {
+    let Some(user_id) = req.extensions().get::<UserSession>().map(|x| x.id) else {
         return Ok(HttpResponse::Unauthorized().finish());
     };
 

--- a/crates/bwmapserver/src/api/random.rs
+++ b/crates/bwmapserver/src/api/random.rs
@@ -38,7 +38,7 @@ async fn random_core(
 
     let maps = search_cache(query, allow_nsfw, &query_params, (**pool).clone()).await?;
 
-    if maps.len() == 0 {
+    if maps.is_empty() {
         return Err(anyhow::anyhow!("no maps found").into());
     }
 

--- a/crates/bwmapserver/src/api/register.rs
+++ b/crates/bwmapserver/src/api/register.rs
@@ -18,7 +18,7 @@ async fn handler2(
         >,
     >,
 ) -> Result<HttpResponse, bwcommon::MyError> {
-    if form.username.len() < 1 {
+    if form.username.is_empty() {
         return Ok(
             HttpResponse::BadRequest().body("The provided username must not be the empty string")
         );
@@ -34,7 +34,7 @@ async fn handler2(
         return Ok(HttpResponse::BadRequest().body("The two provided passwords must match"));
     }
 
-    if form.password.len() < 1 {
+    if form.password.is_empty() {
         return Ok(
             HttpResponse::BadRequest().body("The provided password must not be the empty string")
         );

--- a/crates/bwmapserver/src/api/uiv2/map_info.rs
+++ b/crates/bwmapserver/src/api/uiv2/map_info.rs
@@ -100,7 +100,7 @@ async fn map_info(
 
     let user_id = req.extensions().get::<UserSession>().map(|x| x.id);
 
-    if nsfw && user_id == None {
+    if nsfw && user_id.is_none() {
         return Ok(HttpResponse::Forbidden().finish().customize());
     }
 
@@ -241,7 +241,7 @@ async fn map_info(
     .unwrap_or_default();
 
     let unique_terrain_tiles = (if let Ok(x) = &parsed_chk.mtxm {
-        let hash_set: std::collections::HashSet<u16> = x.data.iter().cloned().collect();
+        let hash_set: std::collections::HashSet<u16> = x.data.iter().copied().collect();
         Some(hash_set.len())
     } else {
         None
@@ -276,23 +276,21 @@ async fn map_info(
 
         for trigger in &parsed_triggers {
             for condition in &trigger.conditions {
-                match condition {
-                    bwmap::Condition::Deaths {
-                        player: _,
-                        comparison: _,
-                        unit_type: _,
-                        number: _,
-                        eud_offset,
-                    } => {
-                        if *eud_offset < 0x58A364 || *eud_offset >= 0x58CE24 {
-                            get_death_euds += 1;
-                        }
-
-                        if *eud_offset >= 0x51A280 && *eud_offset < 0x51A2E0 {
-                            trigger_list_reads += 1;
-                        }
+                if let bwmap::Condition::Deaths {
+                    player: _,
+                    comparison: _,
+                    unit_type: _,
+                    number: _,
+                    eud_offset,
+                } = condition
+                {
+                    if *eud_offset < 0x58A364 || *eud_offset >= 0x58CE24 {
+                        get_death_euds += 1;
                     }
-                    _ => {}
+
+                    if *eud_offset >= 0x51A280 && *eud_offset < 0x51A2E0 {
+                        trigger_list_reads += 1;
+                    }
                 }
             }
             for action in &trigger.actions {
@@ -352,7 +350,7 @@ async fn map_info(
             }
         }
 
-        Vec::from_iter(set.drain().cloned())
+        set.drain().cloned().collect::<Vec<_>>()
     };
 
     let (scenario_name, scenario_description) = if let Ok(x) = &parsed_chk.sprp {

--- a/crates/bwmapserver/src/api/uiv2/mod.rs
+++ b/crates/bwmapserver/src/api/uiv2/mod.rs
@@ -317,7 +317,7 @@ async fn get_minimap(
 
     let user_id = req.extensions().get::<UserSession>().map(|x| x.id);
 
-    if nsfw && user_id == None {
+    if nsfw && user_id.is_none() {
         return Ok(HttpResponse::Forbidden().finish().customize());
     }
 
@@ -427,7 +427,7 @@ async fn get_map_image(
 
     let user_id = req.extensions().get::<UserSession>().map(|x| x.id);
 
-    if nsfw && user_id == None {
+    if nsfw && user_id.is_none() {
         return Ok(HttpResponse::Forbidden().finish().customize());
     }
 

--- a/crates/bwmapserver/src/api/uiv2/search.rs
+++ b/crates/bwmapserver/src/api/uiv2/search.rs
@@ -63,5 +63,5 @@ async fn search(
     query_params: Query<SearchParams>,
     pool: Data<Pool<PostgresConnectionManager<NoTls>>>,
 ) -> Result<impl Responder, bwcommon::MyError> {
-    handler(req, "".to_owned(), query_params, pool).await
+    handler(req, String::new(), query_params, pool).await
 }

--- a/crates/bwmapserver/src/api/uiv2/upload.rs
+++ b/crates/bwmapserver/src/api/uiv2/upload.rs
@@ -54,11 +54,7 @@ async fn upload_map(
             .customize());
     }
 
-    let user_id = req
-        .extensions()
-        .get::<UserSession>()
-        .map(|x| x.id)
-        .unwrap_or(10);
+    let user_id = req.extensions().get::<UserSession>().map_or(10, |x| x.id);
 
     let query = query.into_inner();
 

--- a/crates/bwmapserver/src/db.rs
+++ b/crates/bwmapserver/src/db.rs
@@ -74,9 +74,9 @@ pub(crate) async fn change_password(
 
     let hashed_password = {
         let mut hasher = Sha256::new();
-        hasher.update(&username.as_bytes());
-        hasher.update(&password.as_bytes());
-        hasher.update(&salt.as_bytes());
+        hasher.update(username.as_bytes());
+        hasher.update(password.as_bytes());
+        hasher.update(salt.as_bytes());
         format!("{:x}", hasher.finalize())
     };
 
@@ -109,9 +109,9 @@ pub(crate) async fn check_password(
 
     let hashed_provided_password = {
         let mut hasher = Sha256::new();
-        hasher.update(&username.as_bytes());
-        hasher.update(&password.as_bytes());
-        hasher.update(&salt.as_bytes());
+        hasher.update(username.as_bytes());
+        hasher.update(password.as_bytes());
+        hasher.update(salt.as_bytes());
         format!("{:x}", hasher.finalize())
     };
 
@@ -142,9 +142,9 @@ pub(crate) async fn change_username(
 
     let hashed_password = {
         let mut hasher = Sha256::new();
-        hasher.update(&new_username.as_bytes());
-        hasher.update(&password.as_bytes());
-        hasher.update(&salt.as_bytes());
+        hasher.update(new_username.as_bytes());
+        hasher.update(password.as_bytes());
+        hasher.update(salt.as_bytes());
         format!("{:x}", hasher.finalize())
     };
 
@@ -250,9 +250,9 @@ pub(crate) async fn login(
 
     let hashed_password = {
         let mut hasher = Sha256::new();
-        hasher.update(&username.as_bytes());
-        hasher.update(&password.as_bytes());
-        hasher.update(&salt.as_bytes());
+        hasher.update(username.as_bytes());
+        hasher.update(password.as_bytes());
+        hasher.update(salt.as_bytes());
         format!("{:x}", hasher.finalize())
     };
 
@@ -282,9 +282,9 @@ pub(crate) async fn register(
 
     let hashed_password = {
         let mut hasher = Sha256::new();
-        hasher.update(&username.as_bytes());
-        hasher.update(&password.as_bytes());
-        hasher.update(&salt.as_bytes());
+        hasher.update(username.as_bytes());
+        hasher.update(password.as_bytes());
+        hasher.update(salt.as_bytes());
         format!("{:x}", hasher.finalize())
     };
 

--- a/crates/bwmapserver/src/hacks.rs
+++ b/crates/bwmapserver/src/hacks.rs
@@ -319,8 +319,8 @@ pub(crate) async fn denormalize_all(
         map_ids.iter(),
         || {},
         128,
-        |x, y| info!("Completed: {}, ret: {:?}", x, y),
-        |_: (), map_id: &i64| async {
+        |x, y| info!("Completed: {x}, ret: {y:?}"),
+        |(): (), map_id: &i64| async {
             let mut con = pool.get().await?;
             let mut tx = con.transaction().await?;
             bwcommon::denormalize_map_tx(*map_id, &mut tx).await?;
@@ -554,7 +554,7 @@ where
             }
         }
 
-        if futs.len() == 0 {
+        if futs.is_empty() {
             break;
         }
 

--- a/crates/bwmapserver/src/middleware/postgreslogging.rs
+++ b/crates/bwmapserver/src/middleware/postgreslogging.rs
@@ -177,7 +177,7 @@ where
                                 .await? == 1);
 
                             anyhow::Ok(())
-                        }.await.unwrap()
+                        }.await.unwrap();
                     });
 
                     Ok(res)
@@ -194,7 +194,7 @@ where
                             anyhow::ensure!(con.execute("INSERT INTO userlogs (log_time, host, ip_addr, remote_addr, tac, tracking_analytics_was_provided_by_request, trace_id, path, query_string, method, version, user_agent, error, if_modified_since, if_none_match, sec_ch_ua, sec_ch_ua_mobile, sec_ch_ua_platform, accept_language, accept_encoding, accept, cookies, request_time_us, user_id, user_username, user_token, referer) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)", &[&now, &host, &real_addr, &remote_addr, &tracking_analytics_id, &tracking_analytics_was_provided_by_request, &trace_id, &path, &query_string, &method, &version, &user_agent, &err_string, &if_modified_since, &if_none_match, &sec_ch_ua, &sec_ch_ua_mobile, &sec_ch_ua_platform, &accept_language, &accept_encoding, &accept, &cookies, &request_time, &user_id, &user_username, &user_token, &referer]).await? == 1);
 
                             anyhow::Ok(())
-                        }.await.unwrap()
+                        }.await.unwrap();
                     });
 
                     Err(err)

--- a/crates/bwmapserver/src/middleware/traceid.rs
+++ b/crates/bwmapserver/src/middleware/traceid.rs
@@ -68,18 +68,17 @@ where
             .unwrap_or("x.x.x.x")
             .to_owned();
 
-        let user_agent = req
-            .headers()
-            .get("user-agent")
-            .map(|x| x.to_str().unwrap_or("couldn't unwrap").to_owned())
-            .unwrap_or_else(|| "couldn't unwrap2".to_string());
+        let user_agent = req.headers().get("user-agent").map_or_else(
+            || "couldn't unwrap2".to_string(),
+            |x| x.to_str().unwrap_or("couldn't unwrap").to_owned(),
+        );
 
         req.extensions_mut().insert(TraceID {
             id: trace_id.clone(),
             start_time: Instant::now(),
         });
 
-        tracing::Span::current().record("trace_id", &trace_id.as_str());
+        tracing::Span::current().record("trace_id", trace_id.as_str());
         let fut = self.service.call(req);
 
         async move {

--- a/crates/bwmapserver/src/middleware/trackinganalytics.rs
+++ b/crates/bwmapserver/src/middleware/trackinganalytics.rs
@@ -86,7 +86,7 @@ where
                 .connection_info()
                 .realip_remote_addr()
                 .unwrap_or("default:5000")
-                .split(":")
+                .split(':')
                 .next()
                 .unwrap_or("default")
                 .to_owned();

--- a/crates/bwmapserver/src/middleware/usersession.rs
+++ b/crates/bwmapserver/src/middleware/usersession.rs
@@ -130,12 +130,12 @@ where
                             token: db_idtoken.1,
                         });
 
-                        return s.call(req).await;
+                        s.call(req).await
                     } else {
-                        return Ok(req.into_response(log_out_user()));
+                        Ok(req.into_response(log_out_user()))
                     }
                 } else {
-                    return Ok(req.into_response(log_out_user()));
+                    Ok(req.into_response(log_out_user()))
                 }
             } else {
                 Ok(s.call(req).await?)

--- a/crates/bwmapserver/src/pumpers.rs
+++ b/crates/bwmapserver/src/pumpers.rs
@@ -118,7 +118,7 @@ pub async fn start_backblaze_pumper(client: reqwest::Client) -> Result<()> {
                     )
                     .await
                     {
-                        Ok(_) => {}
+                        Ok(()) => {}
                         Err(e) => {
                             error!("failed to b2_upload_file: {e}");
                             continue 'full_retry;
@@ -127,7 +127,7 @@ pub async fn start_backblaze_pumper(client: reqwest::Client) -> Result<()> {
 
                     // Only proceed the file to the next stage if it was uploaded successfully.
                     match tokio::fs::remove_file(entry.path()).await {
-                        Ok(_) => {}
+                        Ok(()) => {}
                         Err(e) => {
                             error!("failed to remove file: {e}");
                             continue;

--- a/crates/bwmapserver/src/search2.rs
+++ b/crates/bwmapserver/src/search2.rs
@@ -88,8 +88,8 @@ pub async fn search_cache(
                 ((modified_time <= $12 and modified_time >= $13) or modified_time is null) and
                 ($19 = '' or account.username = $19)
             group by map.id, chkdenorm.scenario_name, uploaded_time, chkdenorm.width, chkdenorm.height, chkdenorm.tileset, chkdenorm.human_players, chkdenorm.computer_players
-            order by {} {}
-            ", sort, sortorder);
+            order by {sort} {sortorder}
+            ");
 
         con.query(
             &qs,
@@ -166,8 +166,8 @@ pub async fn search_cache(
                         ((modified_time <= $19 and modified_time >= $20) or modified_time is null) and
                         ($25 = '' or account.username = $25)
                     group by map.id, chkdenorm.scenario_name, dist2
-                    order by {} {}
-                ) as sq3",  sort, sortorder);
+                    order by {sort} {sortorder}
+                ) as sq3");
 
         con.query(
             &qs,
@@ -240,7 +240,7 @@ fn default2524608000000() -> i64 {
 }
 
 fn defaultempty() -> String {
-    "".to_owned()
+    String::new()
 }
 
 fn defaultfalse() -> bool {

--- a/crates/bwmapserver/src/tests.rs
+++ b/crates/bwmapserver/src/tests.rs
@@ -1,11 +1,41 @@
-#[cfg(test)]
-mod tests {
-    #[ignore]
-    #[tokio::test]
-    async fn it_works_2() {
-        let path = "/home/stan/Downloads/failedmaps/FAILED/badmaps/err13/Mission22.scx";
+#[ignore]
+#[tokio::test]
+async fn it_works_2() {
+    let path = "/home/stan/Downloads/failedmaps/FAILED/badmaps/err13/Mission22.scx";
 
-        let chk = bwmpq::get_chk_from_mpq_filename(path);
+    let chk = bwmpq::get_chk_from_mpq_filename(path);
+
+    match chk {
+        Ok(chk) => {
+            let parsed = bwmap::ParsedChk::from_bytes(&chk);
+            let scenario_index = parsed
+                .sprp
+                .as_ref()
+                .unwrap()
+                .scenario_name_string_number
+                .clone() as usize;
+
+            let scenario = parsed.get_string(scenario_index).unwrap();
+
+            println!("{path:96}: OK scenario: {scenario:?}");
+        }
+        Err(err) => println!("{path:96}: ERR:{err}"),
+    }
+}
+
+#[ignore]
+#[tokio::test]
+async fn it_works() {
+    for entry in walkdir::WalkDir::new("/home/stan/Downloads/failedmaps/FAILED") {
+        let Ok(entry) = entry else {
+            continue;
+        };
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let chk = bwmpq::get_chk_from_mpq_filename(entry.path());
 
         match chk {
             Ok(chk) => {
@@ -19,64 +49,9 @@ mod tests {
 
                 let scenario = parsed.get_string(scenario_index).unwrap();
 
-                println!("{:96}: OK scenario: {:?}", path, scenario);
-                // tokio::fs::rename(
-                //     entry.path(),
-                //     format!(
-                //         "/home/stan/Downloads/failedmaps/ok/{}",
-                //         entry.file_name().to_string_lossy()
-                //     ),
-                // )
-                // .await
-                // .unwrap();
-
-                return;
+                println!("{:96}: OK scenario: {scenario:?}", entry.path().display());
             }
-            Err(err) => println!("{:96}: ERR:{}", path, err),
-        }
-    }
-
-    #[ignore]
-    #[tokio::test]
-    async fn it_works() {
-        for entry in walkdir::WalkDir::new("/home/stan/Downloads/failedmaps/FAILED").into_iter() {
-            let Ok(entry) = entry else {
-                continue;
-            };
-
-            if !entry.file_type().is_file() {
-                continue;
-            }
-
-            let chk = bwmpq::get_chk_from_mpq_filename(entry.path());
-
-            match chk {
-                Ok(chk) => {
-                    let parsed = bwmap::ParsedChk::from_bytes(&chk);
-                    let scenario_index = parsed
-                        .sprp
-                        .as_ref()
-                        .unwrap()
-                        .scenario_name_string_number
-                        .clone() as usize;
-
-                    let scenario = parsed.get_string(scenario_index).unwrap();
-
-                    println!("{:96}: OK scenario: {:?}", entry.path().display(), scenario);
-                    // tokio::fs::rename(
-                    //     entry.path(),
-                    //     format!(
-                    //         "/home/stan/Downloads/failedmaps/ok/{}",
-                    //         entry.file_name().to_string_lossy()
-                    //     ),
-                    // )
-                    // .await
-                    // .unwrap();
-
-                    continue;
-                }
-                Err(err) => println!("{:96}: ERR:{}", entry.path().display(), err),
-            }
+            Err(err) => println!("{:96}: ERR:{err}", entry.path().display()),
         }
     }
 }

--- a/crates/bwmapserver/src/uiv2/index.rs
+++ b/crates/bwmapserver/src/uiv2/index.rs
@@ -130,7 +130,7 @@ pub async fn search_no_query(
     manifest: Data<HashMap<String, ManifestChunk>>,
 ) -> Result<impl Responder, MyError> {
     search_handler(
-        "".to_owned(),
+        String::new(),
         &search_params.into_inner(),
         req,
         pool,
@@ -234,7 +234,7 @@ pub async fn map(
     let user_id = req.extensions().get::<UserSession>().map(|x| x.id);
 
     let map_id = path.into_inner();
-    let map_id = if map_id.chars().all(|x| x.is_numeric()) && map_id.len() < 8 {
+    let map_id = if map_id.chars().all(char::is_numeric) && map_id.len() < 8 {
         return Ok(HttpResponse::PermanentRedirect()
             .append_header((
                 "Location",
@@ -248,12 +248,12 @@ pub async fn map(
             ))
             .finish()
             .customize());
+    } else if let Ok(id) =
+        bwcommon::get_db_id_from_web_id(map_id.as_str(), crate::util::SEED_MAP_ID)
+    {
+        id
     } else {
-        if let Ok(id) = bwcommon::get_db_id_from_web_id(map_id.as_str(), crate::util::SEED_MAP_ID) {
-            id
-        } else {
-            return Ok(HttpResponse::NotFound().finish().customize());
-        }
+        return Ok(HttpResponse::NotFound().finish().customize());
     };
 
     let (chkblob, uploaded_by, nsfw, blackholed) = {
@@ -277,7 +277,7 @@ pub async fn map(
             )
             .await?;
 
-        if rows.len() == 0 {
+        if rows.is_empty() {
             return Ok(HttpResponse::NotFound().finish().customize());
         }
 
@@ -307,22 +307,18 @@ pub async fn map(
     let (scenario, description) = if let Ok(sprp) = &parsed_chk.sprp {
         let scenario = if sprp.scenario_name_string_number == 0 {
             "Untitled Scenario".to_string()
+        } else if let Ok(s) = parsed_chk.get_string(sprp.scenario_name_string_number as usize) {
+            sanitize_sc_string(s.as_str())
         } else {
-            if let Ok(s) = parsed_chk.get_string(sprp.scenario_name_string_number as usize) {
-                sanitize_sc_string(s.as_str())
-            } else {
-                "<<Could not get scenario name>>".to_owned()
-            }
+            "<<Could not get scenario name>>".to_owned()
         };
 
         let description = if sprp.description_string_number == 0 {
-            "".to_string()
+            String::new()
+        } else if let Ok(s) = parsed_chk.get_string(sprp.description_string_number as usize) {
+            sanitize_sc_string(s.as_str())
         } else {
-            if let Ok(s) = parsed_chk.get_string(sprp.description_string_number as usize) {
-                sanitize_sc_string(s.as_str())
-            } else {
-                "<<Could not get scenario description>>".to_owned()
-            }
+            "<<Could not get scenario description>>".to_owned()
         };
 
         (scenario, description)
@@ -333,7 +329,7 @@ pub async fn map(
         )
     };
 
-    if nsfw && user_id == None {
+    if nsfw && user_id.is_none() {
         return Ok(HttpResponse::Forbidden().finish().customize());
     }
 

--- a/crates/bwmapserver/src/util.rs
+++ b/crates/bwmapserver/src/util.rs
@@ -14,11 +14,11 @@ pub fn is_dev_mode() -> bool {
 pub(crate) fn sanitize_sc_string(s: &str) -> String {
     // split string by left or right marks
 
-    let mut strings: Vec<_> = s.split(|x| x == '\u{0012}' || x == '\u{0013}').collect();
+    let mut strings: Vec<_> = s.split(['\u{0012}', '\u{0013}']).collect();
 
     strings.sort_by_key(|x| std::cmp::Reverse(x.len()));
 
-    if strings.len() == 0 {
+    if strings.is_empty() {
         String::new()
     } else {
         strings[0].chars().filter(|&x| x >= ' ').collect()

--- a/crates/bwminimaprender/Cargo.toml
+++ b/crates/bwminimaprender/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "*"
-image = { version = "*", default-features = false, features = ["png"] }
-lazy_static = "*"
-tracing = "*"
+anyhow = "1.0.99"
+image = { version = "0.25.6", default-features = false, features = ["png"] }
+lazy_static = "1.5.0"
+tracing = "0.1.41"
+
+[lints]
+workspace = true

--- a/crates/bwminimaprender/src/minimap.rs
+++ b/crates/bwminimaprender/src/minimap.rs
@@ -123,7 +123,7 @@ pub fn calculate_perceptual_hash(png: &[u8]) -> Result<[u8; 16 * 16 / 8]> {
 
     let ph16x16: Vec<u8> = ph16x16
         .iter()
-        .map(|x| if *x < ph16x16_avg { 0 } else { 1 })
+        .map(|x| u8::from(*x >= ph16x16_avg))
         .collect::<Vec<u8>>()
         .chunks_exact(8)
         .map(|x| x.iter().fold(0u8, |acc, x| (acc << 1) | *x))

--- a/crates/bwmpq/Cargo.toml
+++ b/crates/bwmpq/Cargo.toml
@@ -6,14 +6,17 @@ edition = "2021"
 [dependencies]
 stormlib-bindings = { path = "../stormlib-bindings" }
 
-anyhow = { version = "*", features = ["backtrace"] }
-scopeguard = "*"
-lazy_static = "*"
-tracing = "*"
-uuid = { version = "*", features = ["v4"] }
+anyhow = { version = "1.0.99", features = ["backtrace"] }
+scopeguard = "1.2.0"
+lazy_static = "1.5.0"
+tracing = "0.1.41"
+uuid = { version = "1.18.0", features = ["v4"] }
 
 [dev-dependencies]
-reqwest = { version = "*", default-features = false, features = ["json", "http2", "rustls-tls"] }
-tokio = { version = "1", features = ["full"] }
-sha2 = "*"
-futures-util = "*"
+reqwest = { version = "0.12.4", default-features = false, features = ["json", "http2", "rustls-tls"] }
+tokio = { version = "1.47.1", features = ["full"] }
+sha2 = "0.10.9"
+futures-util = "0.3.31"
+
+[lints]
+workspace = true

--- a/crates/bwmpq/src/mpq.rs
+++ b/crates/bwmpq/src/mpq.rs
@@ -49,12 +49,7 @@ pub fn get_chk_from_mpq_filename<T: AsRef<Path>>(filename: T) -> Result<Vec<u8>>
     let _lock = LOCK.lock().unwrap();
     unsafe {
         let mut mpq_handle = 0 as HANDLE;
-        if !SFileOpenArchive(
-            cstr.as_ptr(),
-            0,
-            STREAM_FLAG_READ_ONLY,
-            &mut mpq_handle as *mut _,
-        ) {
+        if !SFileOpenArchive(cstr.as_ptr(), 0, STREAM_FLAG_READ_ONLY, &raw mut mpq_handle) {
             bail!(
                 "SFileOpenArchive. GetLastError: {}, filename: {}",
                 GetLastError(),
@@ -80,12 +75,7 @@ pub fn get_chk_from_mpq_filename<T: AsRef<Path>>(filename: T) -> Result<Vec<u8>>
 
             SFileSetLocale(locale);
             let mut archive_file_handle = 0 as HANDLE;
-            if !SFileOpenFileEx(
-                mpq_handle,
-                cstr.as_ptr(),
-                0,
-                &mut archive_file_handle as *mut _,
-            ) {
+            if !SFileOpenFileEx(mpq_handle, cstr.as_ptr(), 0, &raw mut archive_file_handle) {
                 bail!(
                     "SFileOpenFileEx. GetLastError: {}, filename: {filename}, locale: {locale}",
                     GetLastError()
@@ -108,9 +98,9 @@ pub fn get_chk_from_mpq_filename<T: AsRef<Path>>(filename: T) -> Result<Vec<u8>>
             if !SFileGetFileInfo(
                 archive_file_handle,
                 _SFileInfoClass_SFileInfoLocale,
-                &mut gotten_locale as *mut _ as *mut c_void,
+                (&raw mut gotten_locale).cast::<c_void>(),
                 size_of::<u32>() as u32,
-                0 as *mut _,
+                std::ptr::null_mut(),
             ) {
                 bail!(
                     "SFileGetFileInfo. GetLastError: {}, filename: {filename}, locale: {locale}",
@@ -122,10 +112,9 @@ pub fn get_chk_from_mpq_filename<T: AsRef<Path>>(filename: T) -> Result<Vec<u8>>
                 bail!("not found");
             }
 
-            let file_size_low;
             let mut file_size_high: u32 = 0;
 
-            file_size_low = SFileGetFileSize(archive_file_handle, &mut file_size_high as *mut _);
+            let file_size_low = SFileGetFileSize(archive_file_handle, &raw mut file_size_high);
 
             if file_size_low == SFILE_INVALID_SIZE {
                 bail!(
@@ -145,10 +134,10 @@ pub fn get_chk_from_mpq_filename<T: AsRef<Path>>(filename: T) -> Result<Vec<u8>>
             let mut size: u32 = 0;
             if !SFileReadFile(
                 archive_file_handle,
-                chk_data.as_mut_ptr() as *mut _,
+                chk_data.as_mut_ptr().cast(),
                 chk_data.len() as u32,
-                &mut size as *mut _,
-                0 as *mut _,
+                &raw mut size,
+                std::ptr::null_mut(),
             ) {
                 let last_error = GetLastError();
                 if last_error != ERROR_HANDLE_EOF || size == chk_data.len() as u32 {

--- a/crates/bwmpq/src/test.rs
+++ b/crates/bwmpq/src/test.rs
@@ -41,7 +41,7 @@ where
             }
         }
 
-        if futs.len() == 0 {
+        if futs.is_empty() {
             break;
         }
 
@@ -77,17 +77,13 @@ async fn download_test_artifacts<'a, T: AsRef<Path>, I: Iterator<Item = &'a str>
         |(path, client), id| async move {
             let path = path.join(id);
 
-            match tokio::fs::read(&path).await {
-                Ok(data) => {
-                    if hash(data.as_slice()) != id {
-                    } else {
-                        return;
-                    }
+            if let Ok(data) = tokio::fs::read(&path).await {
+                if hash(data.as_slice()) == id {
+                    return;
                 }
-                Err(_) => {}
             }
 
-            let url = format!("https://scmscx.com/api/maps/{}", id);
+            let url = format!("https://scmscx.com/api/maps/{id}");
             println!("getting: {url}");
 
             let response = client
@@ -98,7 +94,7 @@ async fn download_test_artifacts<'a, T: AsRef<Path>, I: Iterator<Item = &'a str>
                 .unwrap();
             let bytes = response.bytes().await.unwrap();
 
-            assert!(bytes.len() > 0);
+            assert!(!bytes.is_empty());
             assert_eq!(hash(&bytes[..]), id);
 
             tokio::fs::write(path, &bytes[..]).await.unwrap();
@@ -120,7 +116,7 @@ async fn can_extract_chks() {
     for (mpq_hash, chk_hash) in MPQS {
         let mpq_path = dir.join(mpq_hash);
         let mpq_data = tokio::fs::read(&mpq_path).await.unwrap();
-        let mpq_hash2 = hash(&mpq_data.as_slice());
+        let mpq_hash2 = hash(mpq_data.as_slice());
         let chk = get_chk_from_mpq_in_memory(mpq_data.as_slice()).unwrap();
         let chk_hash2 = hash(chk.as_slice());
 

--- a/crates/bwrender/Cargo.toml
+++ b/crates/bwrender/Cargo.toml
@@ -15,30 +15,33 @@ backblaze = { path = "../backblaze" }
 bwmpq = { path = "../bwmpq" }
 
 # Async runtime
-tokio = { version = "*", features = ["rt-multi-thread", "full"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "full"] }
 
 # Database
-bb8-postgres = "*"
+bb8-postgres = "0.9.0"
 
 # HTTP client
-reqwest = { version = "*", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["rustls-tls"] }
 
 # Error handling
-anyhow = "*"
+anyhow = "1.0.99"
 
 # Logging
-tracing = "*"
-tracing-subscriber = { version = "*", features = ["env-filter"] }
-tracing-log = "*"
-log = "*"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+tracing-log = "0.2.0"
+log = "0.4.27"
 
 # Image encoding
-webp = "*"
-image = { version = "*", default-features = false, features = ["png"] }
+webp = "0.3.1"
+image = { version = "0.25.6", default-features = false, features = ["png"] }
 
 # Utilities
-uuid = { version = "*", features = ["v4"] }
-futures-util = "*"
-async-channel = "*"
+uuid = { version = "1.18.0", features = ["v4"] }
+futures-util = "0.3.31"
+async-channel = "2.5.0"
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/bwrender/src/db.rs
+++ b/crates/bwrender/src/db.rs
@@ -38,7 +38,7 @@ pub async fn get_unrendered_maps(pool: &DbPool) -> Result<Vec<UnrenderedMap>> {
 
     let rows = conn
         .query(
-            r#"
+            r"
             SELECT DISTINCT m.id, m.chkblob, m.mapblob2
             FROM map m
             WHERE m.chkblob IS NOT NULL
@@ -46,7 +46,7 @@ pub async fn get_unrendered_maps(pool: &DbPool) -> Result<Vec<UnrenderedMap>> {
               AND m.blackholed = false
               AND m.rendered = false
             ORDER BY m.id DESC
-            "#,
+            ",
             &[],
         )
         .await

--- a/crates/bwrender/src/main.rs
+++ b/crates/bwrender/src/main.rs
@@ -781,7 +781,7 @@ mod tests {
         std::fs::create_dir_all(&output_dir).expect("Failed to create output dir");
 
         // Download the map to a temp file
-        println!("Downloading map from: {}", map_url);
+        println!("Downloading map from: {map_url}");
         let map_data = reqwest::get(&map_url)
             .await
             .expect("Failed to fetch map")
@@ -806,7 +806,7 @@ mod tests {
             .expect("Failed to create renderer");
 
         for &(skin, skin_name) in ALL_SKINS {
-            println!("\n=== Rendering with skin: {} ===", skin_name);
+            println!("\n=== Rendering with skin: {skin_name} ===");
 
             renderer.set_skin(skin);
 
@@ -851,9 +851,9 @@ mod tests {
                 decoded.height()
             );
 
-            let webp_path = format!("{}/{}.webp", output_dir, skin_name);
+            let webp_path = format!("{output_dir}/{skin_name}.webp");
             std::fs::write(&webp_path, &webp_data).expect("Failed to write WebP file");
-            println!("Map saved to: {}", webp_path);
+            println!("Map saved to: {webp_path}");
         }
 
         // Render minimap once (skin-independent)
@@ -875,9 +875,9 @@ mod tests {
                 .expect("Failed to encode minimap PNG");
         println!("Minimap PNG: {} bytes", minimap_png.len());
 
-        let minimap_path = format!("{}/minimap.png", output_dir);
+        let minimap_path = format!("{output_dir}/minimap.png");
         std::fs::write(&minimap_path, &minimap_png).expect("Failed to write minimap PNG");
-        println!("Minimap saved to: {}", minimap_path);
+        println!("Minimap saved to: {minimap_path}");
 
         // Clean up
         let _ = std::fs::remove_file(&map_path);

--- a/crates/bwrender/src/render.rs
+++ b/crates/bwrender/src/render.rs
@@ -59,7 +59,7 @@ impl RenderContext {
             let mut gfx = match GfxUtil::new() {
                 Ok(g) => g,
                 Err(e) => {
-                    let _ = init_tx.send(Err(format!("Failed to create GfxUtil: {}", e)));
+                    let _ = init_tx.send(Err(format!("Failed to create GfxUtil: {e}")));
                     return;
                 }
             };
@@ -69,7 +69,7 @@ impl RenderContext {
                 sc_data_path
             );
             if let Err(e) = gfx.load_sc_data(&sc_data_path) {
-                let _ = init_tx.send(Err(format!("Failed to load SC data: {}", e)));
+                let _ = init_tx.send(Err(format!("Failed to load SC data: {e}")));
                 return;
             }
             info!("Render thread: StarCraft data loaded successfully");
@@ -80,7 +80,7 @@ impl RenderContext {
             let renderer = match gfx.create_renderer(skin) {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = init_tx.send(Err(format!("Failed to create renderer: {}", e)));
+                    let _ = init_tx.send(Err(format!("Failed to create renderer: {e}")));
                     return;
                 }
             };
@@ -140,7 +140,7 @@ fn render_map_internal(
     info!("render_map_internal: loading map from {}", map_path);
     let mut map = gfx
         .load_map(map_path)
-        .map_err(|e| format!("Failed to load map: {}", e))?;
+        .map_err(|e| format!("Failed to load map: {e}"))?;
     info!(
         "render_map_internal: map loaded, size {}x{}",
         map.tile_width(),
@@ -159,7 +159,7 @@ fn render_map_internal(
     let options = RenderOptions::default();
     let map_image = renderer
         .get_raw_image(&map, &options)
-        .map_err(|e| format!("Failed to render map: {}", e))?;
+        .map_err(|e| format!("Failed to render map: {e}"))?;
     info!(
         "render_map_internal: rendered {}x{} map image ({} bytes)",
         map_image.width,
@@ -170,7 +170,7 @@ fn render_map_internal(
     info!("render_map_internal: rendering minimap");
     let minimap_image = renderer
         .get_raw_minimap(&map)
-        .map_err(|e| format!("Failed to render minimap: {}", e))?;
+        .map_err(|e| format!("Failed to render minimap: {e}"))?;
     info!(
         "render_map_internal: rendered {}x{} minimap ({} bytes)",
         minimap_image.width,

--- a/crates/chkdraft-bindings/Cargo.toml
+++ b/crates/chkdraft-bindings/Cargo.toml
@@ -11,3 +11,6 @@ description = "Rust bindings for Chkdraft map rendering library"
 [build-dependencies]
 bindgen = "0.70"
 cc = "1.0"
+
+[lints]
+workspace = true

--- a/crates/chkdraft-bindings/build.rs
+++ b/crates/chkdraft-bindings/build.rs
@@ -25,7 +25,7 @@ fn main() {
     let vcpkg_root = env::var("VCPKG_ROOT").ok().or_else(|| {
         let home = env::var("HOME").unwrap_or_default();
         let candidates = [
-            format!("{}/vcpkg", home),
+            format!("{home}/vcpkg"),
             "/usr/local/vcpkg".to_string(),
             "/opt/vcpkg".to_string(),
         ];
@@ -51,14 +51,14 @@ fn main() {
         );
     });
 
-    let cmake_toolchain = format!("{}/scripts/buildsystems/vcpkg.cmake", vcpkg_root);
+    let cmake_toolchain = format!("{vcpkg_root}/scripts/buildsystems/vcpkg.cmake");
     if Path::new(&cmake_toolchain).exists() {
-        cmake_args.push(format!("-DCMAKE_TOOLCHAIN_FILE={}", cmake_toolchain));
-        eprintln!("Using vcpkg toolchain: {}", cmake_toolchain);
+        cmake_args.push(format!("-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain}"));
+        eprintln!("Using vcpkg toolchain: {cmake_toolchain}");
     }
 
     // Run cmake configure
-    eprintln!("Running cmake configure in {:?}", build_dir);
+    eprintln!("Running cmake configure in {}", build_dir.display());
     let mut cmake_cmd = Command::new("cmake");
     cmake_cmd
         .current_dir(&build_dir)
@@ -71,10 +71,10 @@ fn main() {
         eprintln!("=== CMAKE CONFIGURE FAILED ===");
         eprintln!("stdout: {}", String::from_utf8_lossy(&cmake_output.stdout));
         eprintln!("stderr: {}", String::from_utf8_lossy(&cmake_output.stderr));
-        eprintln!("");
+        eprintln!();
         eprintln!("=== BUILD REQUIREMENTS ===");
         eprintln!("The chkdraft-bindings crate requires vcpkg with several C++ libraries.");
-        eprintln!("");
+        eprintln!();
         eprintln!("  git clone https://github.com/microsoft/vcpkg ~/vcpkg");
         eprintln!("  ~/vcpkg/bootstrap-vcpkg.sh");
         eprintln!("  export VCPKG_ROOT=~/vcpkg");
@@ -104,7 +104,7 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", dir.display());
     }
     for lib in &build_info.static_libs {
-        println!("cargo:rustc-link-lib=static={}", lib);
+        println!("cargo:rustc-link-lib=static={lib}");
     }
 
     // Compile the wrapper
@@ -138,7 +138,7 @@ fn main() {
     cc_build.compile("chkdraft_wrapper");
 
     for lib in &build_info.system_libs {
-        println!("cargo:rustc-link-lib={}", lib);
+        println!("cargo:rustc-link-lib={lib}");
     }
 
     // Generate bindings
@@ -219,9 +219,8 @@ fn watch_directory_recursively(dir: &Path) {
     // Watch the directory itself
     println!("cargo:rerun-if-changed={}", dir.display());
 
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(_) => return,
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
     };
 
     for entry in entries.flatten() {
@@ -236,15 +235,11 @@ fn watch_directory_recursively(dir: &Path) {
             watch_directory_recursively(&path);
         } else if path.is_file() {
             // Watch source files, headers, cmake files, and libraries
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                match ext {
-                    "cpp" | "c" | "h" | "hpp" | "hxx" | "cxx" | "cc" |
-                    "cmake" | "txt" | "json" |  // CMakeLists.txt, vcpkg.json, etc.
-                    "a" => {
-                        println!("cargo:rerun-if-changed={}", path.display());
-                    }
-                    _ => {}
-                }
+            if let Some(
+                "cpp" | "c" | "h" | "hpp" | "hxx" | "cxx" | "cc" | "cmake" | "txt" | "json" | "a",
+            ) = path.extension().and_then(|e| e.to_str())
+            {
+                println!("cargo:rerun-if-changed={}", path.display());
             }
             // Also watch CMakeLists.txt specifically (no extension check needed)
             if path.file_name().and_then(|n| n.to_str()) == Some("CMakeLists.txt") {

--- a/crates/chkdraft-bindings/src/lib.rs
+++ b/crates/chkdraft-bindings/src/lib.rs
@@ -131,7 +131,7 @@ impl RenderOptions {
             draw_stars: self.draw_stars as i32,
             draw_terrain: self.draw_terrain as i32,
             draw_actors: self.draw_actors as i32,
-            draw_fog_player: self.draw_fog_player.map(|p| p as i32).unwrap_or(-1),
+            draw_fog_player: self.draw_fog_player.map_or(-1, |p| p as i32),
             draw_locations: self.draw_locations as i32,
         }
     }
@@ -227,7 +227,7 @@ impl GfxUtil {
         };
 
         let result =
-            unsafe { ffi::chk_gfxutil_load_sc_data(self.ptr, c_path.as_ptr(), &mut error) };
+            unsafe { ffi::chk_gfxutil_load_sc_data(self.ptr, c_path.as_ptr(), &raw mut error) };
 
         if result != 0 {
             return Err(error.into());
@@ -246,7 +246,8 @@ impl GfxUtil {
             message: [0; 256],
         };
 
-        let ptr = unsafe { ffi::chk_gfxutil_create_renderer(self.ptr, skin.to_ffi(), &mut error) };
+        let ptr =
+            unsafe { ffi::chk_gfxutil_create_renderer(self.ptr, skin.to_ffi(), &raw mut error) };
 
         if ptr.is_null() {
             return Err(error.into());
@@ -270,7 +271,7 @@ impl GfxUtil {
             message: [0; 256],
         };
 
-        let ptr = unsafe { ffi::chk_gfxutil_load_map(self.ptr, c_path.as_ptr(), &mut error) };
+        let ptr = unsafe { ffi::chk_gfxutil_load_map(self.ptr, c_path.as_ptr(), &raw mut error) };
 
         if ptr.is_null() {
             return Err(error.into());
@@ -332,9 +333,9 @@ impl Renderer {
             ffi::chk_renderer_save_webp(
                 self.ptr,
                 map.ptr,
-                &ffi_options,
+                &raw const ffi_options,
                 c_path.as_ptr(),
-                &mut error,
+                &raw mut error,
             )
         };
 
@@ -370,7 +371,13 @@ impl Renderer {
         let mut data_ptr: *mut u8 = ptr::null_mut();
 
         let size = unsafe {
-            ffi::chk_renderer_get_webp(self.ptr, map.ptr, &ffi_options, &mut data_ptr, &mut error)
+            ffi::chk_renderer_get_webp(
+                self.ptr,
+                map.ptr,
+                &raw const ffi_options,
+                &raw mut data_ptr,
+                &raw mut error,
+            )
         };
 
         if size == 0 || data_ptr.is_null() {
@@ -410,9 +417,9 @@ impl Renderer {
             ffi::chk_renderer_get_raw_image(
                 self.ptr,
                 map.ptr,
-                &ffi_options,
-                &mut raw_image,
-                &mut error,
+                &raw const ffi_options,
+                &raw mut raw_image,
+                &raw mut error,
             )
         };
 
@@ -451,7 +458,7 @@ impl Renderer {
         };
 
         let success = unsafe {
-            ffi::chk_renderer_get_raw_minimap(self.ptr, map.ptr, &mut raw_image, &mut error)
+            ffi::chk_renderer_get_raw_minimap(self.ptr, map.ptr, &raw mut raw_image, &raw mut error)
         };
 
         if success == 0 || raw_image.data.is_null() {

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -5,18 +5,21 @@ edition = "2021"
 
 [dependencies]
 
-actix-web = "*"
-anyhow = "*"
-tracing = "*"
-tracing-subscriber = { version = "*", features = ["registry", "env-filter", "tracing-log"] }
+actix-web = "4.11.0"
+anyhow = "1.0.99"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["registry", "env-filter", "tracing-log"] }
 #console-subscriber = "*"
-sha2 = "*"
-uuid = { version = "*", features = ["v4"] }
-futures-util = "*"
-futures = "*"
-bytes = "*"
-reqwest = { version = "*", default-features = false, features = ["rustls-tls", "stream"] }
-async-stream = "*"
-bb8-postgres = "*"
-tokio = { version = "*", features = ["full"] }
-serde = "*"
+sha2 = "0.10.9"
+uuid = { version = "1.18.0", features = ["v4"] }
+futures-util = "0.3.31"
+futures = "0.3.31"
+bytes = "1.10.1"
+reqwest = { version = "0.12.4", default-features = false, features = ["rustls-tls", "stream"] }
+async-stream = "0.3.6"
+bb8-postgres = "0.9.0"
+tokio = { version = "1.47.1", features = ["full"] }
+serde = "1.0.219"
+
+[lints]
+workspace = true

--- a/crates/common/src/gsfs.rs
+++ b/crates/common/src/gsfs.rs
@@ -51,7 +51,7 @@ async fn gsfs_put(
     src: impl Stream<Item = Result<Bytes, std::io::Error>> + Sync + Send + 'static,
     dst: impl AsRef<str> + 'static,
 ) -> Result<()> {
-    anyhow::ensure!(dst.as_ref().starts_with("/"), "dst must start with /");
+    anyhow::ensure!(dst.as_ref().starts_with('/'), "dst must start with /");
 
     let response = client
         .put(format!(
@@ -78,7 +78,7 @@ async fn gsfs_get(
     endpoint: &str,
     path: impl AsRef<str> + 'static,
 ) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>>> {
-    anyhow::ensure!(path.as_ref().starts_with("/"), "path must start with /");
+    anyhow::ensure!(path.as_ref().starts_with('/'), "path must start with /");
 
     let response = client
         .get(format!(

--- a/crates/common/src/middleware/postgreslogging.rs
+++ b/crates/common/src/middleware/postgreslogging.rs
@@ -140,7 +140,7 @@ where
                                 .await?;
 
                             anyhow::Ok(())
-                        }.await.unwrap()
+                        }.await.unwrap();
                     });
 
                     Ok(res)
@@ -157,7 +157,7 @@ where
                             con.execute("INSERT INTO userlogs (timestamp, host, real_addr, remote_addr, tracking_analytics_id, tracking_analytics_was_provided_by_request, trace_id, path, query_string, method, version, user_agent, error, if_modified_since, if_none_match, sec_ch_ua, sec_ch_ua_mobile, sec_ch_ua_platform, accept_language, accept_encoding, accept, cookies, request_time_us) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)", &[&now, &host, &real_addr, &remote_addr, &tracking_analytics_id, &tracking_analytics_was_provided_by_request, &trace_id, &path, &query_string, &method, &version, &user_agent, &err_string, &if_modified_since, &if_none_match, &sec_ch_ua, &sec_ch_ua_mobile, &sec_ch_ua_platform, &accept_language, &accept_encoding, &accept, &cookies, &request_time]).await?;
 
                             anyhow::Ok(())
-                        }.await.unwrap()
+                        }.await.unwrap();
                     });
 
                     Err(err)

--- a/crates/common/src/middleware/traceid.rs
+++ b/crates/common/src/middleware/traceid.rs
@@ -65,16 +65,15 @@ where
             .realip_remote_addr()
             .unwrap_or("x.x.x.x")
             .to_owned();
-        let user_agent = req
-            .headers()
-            .get("user-agent")
-            .map(|x| x.to_str().unwrap_or("couldn't unwrap").to_owned())
-            .unwrap_or_else(|| "couldn't unwrap2".to_string());
+        let user_agent = req.headers().get("user-agent").map_or_else(
+            || "couldn't unwrap2".to_string(),
+            |x| x.to_str().unwrap_or("couldn't unwrap").to_owned(),
+        );
         req.extensions_mut().insert(TraceID {
             id: trace_id.clone(),
             start_time: Instant::now(),
         });
-        tracing::Span::current().record("trace_id", &trace_id.as_str());
+        tracing::Span::current().record("trace_id", trace_id.as_str());
         info!("traceid: {}", trace_id);
         let fut = self.service.call(req);
         async move {

--- a/crates/common/src/middleware/trackinganalytics.rs
+++ b/crates/common/src/middleware/trackinganalytics.rs
@@ -91,7 +91,7 @@ where
                 .connection_info()
                 .realip_remote_addr()
                 .unwrap_or("default:5000")
-                .split(":")
+                .split(':')
                 .next()
                 .unwrap_or("default")
                 .to_owned();

--- a/crates/compact_enc_det-bindings/Cargo.toml
+++ b/crates/compact_enc_det-bindings/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2021"
 [dependencies]
 
 [build-dependencies]
-bindgen = "*"
+bindgen = "0.70.1"
+
+[lints]
+workspace = true

--- a/crates/compact_enc_det-bindings/build.rs
+++ b/crates/compact_enc_det-bindings/build.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn main() {
     assert!(Command::new("bash")
         .current_dir("compact_enc_det")
-        .args(&["./autogen.sh"])
+        .args(["./autogen.sh"])
         .status()
         .expect("failed to autogen")
         .success());

--- a/crates/stormlib-bindings/Cargo.toml
+++ b/crates/stormlib-bindings/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2021"
 [dependencies]
 
 [build-dependencies]
-bindgen = "*"
+bindgen = "0.70.1"
+
+[lints]
+workspace = true

--- a/crates/stormlib-bindings/build.rs
+++ b/crates/stormlib-bindings/build.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn main() {
     assert!(Command::new("cmake")
         .current_dir("StormLib")
-        .args(&["CMakeLists.txt"])
+        .args(["CMakeLists.txt"])
         .status()
         .expect("failed to cmake")
         .success());
@@ -22,7 +22,7 @@ fn main() {
 
     assert!(Command::new("cmake")
         .current_dir("bzip2")
-        .args(&["CMakeLists.txt", "-DENABLE_STATIC_LIB=1"])
+        .args(["CMakeLists.txt", "-DENABLE_STATIC_LIB=1"])
         .status()
         .expect("failed to cmake")
         .success());
@@ -36,7 +36,7 @@ fn main() {
 
     assert!(Command::new("bash")
         .current_dir("zlib")
-        .args(&["./configure"])
+        .args(["./configure"])
         .status()
         .expect("failed to configure")
         .success());

--- a/crates/stormlib-bindings/src/bindings.rs
+++ b/crates/stormlib-bindings/src/bindings.rs
@@ -5,6 +5,8 @@
 #![allow(dead_code)]
 #![allow(deref_nullptr)]
 #![allow(clippy::ptr_offset_with_cast)]
+#![allow(clippy::semicolon_if_nothing_returned)]
+#![allow(clippy::missing_safety_doc)]
 #![allow(unnecessary_transmutes)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/uchardet-bindings/Cargo.toml
+++ b/crates/uchardet-bindings/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2021"
 [dependencies]
 
 [build-dependencies]
-bindgen = "*"
+bindgen = "0.70.1"
+
+[lints]
+workspace = true

--- a/crates/uchardet-bindings/build.rs
+++ b/crates/uchardet-bindings/build.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn main() {
     assert!(Command::new("cmake")
         .current_dir("uchardet")
-        .args(&["CMakeLists.txt"])
+        .args(["CMakeLists.txt"])
         .status()
         .expect("failed to cmake")
         .success());


### PR DESCRIPTION
Configure all clippy lint groups (correctness, suspicious, complexity, perf, style, pedantic, cargo) at deny level in workspace Cargo.toml, replacing the CLI flags in the Makefile. Allow commonly noisy pedantic lints and suppress generated-code lints in binding crates.

Pin all dependency versions to precise values resolved from Cargo.lock, removing all wildcard version = "*" specs.

Fix all lint violations across the codebase.